### PR TITLE
Remove PathPrefix + add http to https redirect

### DIFF
--- a/manifests/argocd/httproutes.yaml
+++ b/manifests/argocd/httproutes.yaml
@@ -13,7 +13,9 @@ spec:
   - backendRefs:
     - name: argocd-server
       port: 80
-    matches:
-    - path:
-        type: PathPrefix
-        value: /
+  - filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        statusCode: 301
+        port: 443


### PR DESCRIPTION
PathPrefix was causing a cache issue, removed it and now ArgoCD seems to work as expected.
Took that moment to redirect http to https.