### PR TITLE
Add observability using Netdata

### DIFF
--- a/docs/src/Maintenance/monitoring.md
+++ b/docs/src/Maintenance/monitoring.md
@@ -1,0 +1,5 @@
+# Monitoring
+
+## Netdata
+
+Netdata is a highly performant monitoring and troubleshooting tool for Linux. My choice is motivated by the fact that it's opensource and self-hosted, with deep integration with Kubernetes and deep observability. This one will be used only locally. More information can be found [here](https://github.com/netdata/netdata).

--- a/shared-resources/netdata/httproute.yaml
+++ b/shared-resources/netdata/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: netdata-https
+spec:
+  hostnames:
+  - netdata.menia.cc
+  parentRefs:
+  - name: shared-gateway
+    namespace: default
+    sectionName: shared-https
+  rules:
+  - backendRefs:
+    - name: netdata
+      port: 19999

--- a/shared-resources/netdata/kustomization.yaml
+++ b/shared-resources/netdata/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: netdata
+
+helmCharts:
+  - name: netdata
+    repo: https://netdata.github.io/helmchart/
+    releaseName: netdata
+    namespace: netdata
+    valuesInline:
+      ingress: false
+      k8sState:
+        podAnnotationAppArmor:
+          enabled: false
+      child:
+        podAnnotationAppArmor:
+          enabled: false
+
+resources:
+  - namespace.yaml
+  - httproute.yaml

--- a/shared-resources/netdata/namespace.yaml
+++ b/shared-resources/netdata/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netdata
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest


### PR DESCRIPTION
I plan to add VictoriaMetrics, but I've seen more values in netdata for observability regarding cluster itself. Will add VictoriaMetrics later, for other metrics. This resource will stay on internal network only for privacy and security.

Also would be interesting to check if I can use netdata for `kubectl top` commands.

![image](https://github.com/user-attachments/assets/f2140dc8-f5a7-4350-b5ef-7b2b3e95264e)