### PR TITLE
Chore(talos): Replace Talos ISO by Talos image from their factory with required extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
-# Kubernetes #
+# Infrastructure
+**/controlplane.yaml
+**/worker.yaml
+
+# Kubernetes
 **/secret*.yaml
 !**/secret*.enc.yaml
 !**/*generator*.yaml
 
-# Helm #
+# Helm
 **/charts/
 
 # MkDocs

--- a/infra/controlplane.enc.yaml
+++ b/infra/controlplane.enc.yaml
@@ -192,9 +192,6 @@ machine:
         # # Allows for supplying additional system extension images to install on top of base Talos image.
         # extensions:
         #     - image: ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0 # System extension image.
-        extensions:
-            - image: ghcr.io/siderolabs/iscsi-tools:v0.1.5
-            - image: ghcr.io/siderolabs/util-linux-tools:2.40.2
     # Used to configure the machine's container image registry mirrors.
     registries: {}
     # # Specifies mirror configuration for each registry host namespace.
@@ -540,8 +537,8 @@ sops:
             dXd2dnVaS29CS3hNb3p5dWdmQ1BLaHcKwLPI9qRiB2mdBp3H/ZwlZya+pbz9MKCe
             v8cd2yc34oM1wV1cqnGDtmGjqAXg1AgCHlei2k9s3o6J6aZsW5pdUg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-10-14T15:04:20Z"
-    mac: ENC[AES256_GCM,data:jEMHz2TOk2d++aGTFeIUNJh21rq7AOGhGFWoqWwxXFtzi0r1+mxDWOIT2NX69jacKEcOL8pqnAXaHpVk1YWl5vDaxZ0Ak9HH2daOyPsebTfwQ4fEb1TWkM1REUmvpo20o8UiihAZulp6t6/ukO8cN/0LfKzSF8VvO2oGngrJlB4=,iv:FZooYgwcd48itIvBB5DeFA3UOI4rUB6cu72+MmfozPI=,tag:b0kfnA761bK8UaeCEKq3ag==,type:str]
+    lastmodified: "2024-10-14T15:21:48Z"
+    mac: ENC[AES256_GCM,data:d8R3ZMUbKkqmK+vW4qvDExJ/BaI2tnrCkRNJ7vRk4L1MKfd9vM9Gm8WaIHp3tTK/CiOZPfSVAH6tN1tlwGA16jhDTDRL08kMSlqSfojynqQinthnac5W9i+EUjkDfxIknaI6PWOB0BTKrXIwopZE+jmQ5ZZfU/NDaAOP1lOKJWU=,iv:6mhQXjKaCZKeHzcNwfYqWmBS+x1gfKGkBGOBGC3vy8g=,tag:IMycHDyLGrLtW/SRLV+GGw==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData|ca|crt|key|id|secret|token|aggregatorCA|serviceAccount|bootstraptoken|secretboxencryptionsecret|secretboxEncryptionSecret|clientSecret|clientId)$
     version: 3.9.1

--- a/infra/controlplane.enc.yaml
+++ b/infra/controlplane.enc.yaml
@@ -6,13 +6,13 @@ persist: true
 # Provides machine specific configuration options.
 machine:
     # Defines the role of the machine within the cluster.
-    type: worker
+    type: controlplane
     # The `token` is used by a machine to join the PKI of the cluster.
-    token: ENC[AES256_GCM,data:yZbLRIwpKdObBYPqOEuhsnbzderFWrs=,iv:W0i868T3PT3WyckCHuLcCrwW7x4C8d6qNetJpxlF5LU=,tag:OieYiVF1oVLxyRt1Kfl8Sg==,type:str]
+    token: ENC[AES256_GCM,data:yAZLYZhdoM6BqgAqgrICpU3Z4ZPmJZA=,iv:MQc25uiF4hnp1EYrD+qtdHP/p3Gl1UDuUfUTKxF39Rc=,tag:XRI4QtF2OhbTywt4IRTHbg==,type:str]
     # The root certificate authority of the PKI.
     ca:
-        crt: ENC[AES256_GCM,data:f1cD5xkxLIcHRObSAu8g67/ik0jSvo8XONxJ0FDmbNBEDXnUQ7gYyTfk9sRhXYUVJ3MjWv8CF1dNVxdG8v9QfEMLdj4t5JC7pqBTaX/HUIwAcbwfM8aQZ6gUhNg4yd8vwkfMyU7OHuZEndR+Xwb/KPpObnbi9cvO38AIV8rrMcJhQtw/2eByIvZzYkTSimr+I4lVHAaxE0ALakIb4PcIIU4RHbbEXu2762ITFnvbk4LLo4cHy5Nl4a6k5mxezivKY1syD+LepUHYjx6fMzwjMNvlI/3vncuKLhHSNvTd1IgVtXs5+XQo3uNn7NKbnN5cGEJ3aisL1fsgmn9NOog4oJAvyIl/5TBfYDup26PuVN91R1BeuMS2kHDyKVXSfKJ5IgvUM9AcBE34SHQdEU8al74uMj0Zjc8Esm6kr9AC8zA0lpaHEn3dM6BDE9vKH9Uw2SLElysNlTf0hMMQ+GL/a/WJZSpZx12bnTJFyAB1IeIXNHCPrbYhV0TbHYj44tlpD4LbjmQoqWZoFNWlp9GVqBKTi9vYxCYtUbiNMCg8p0XpxyZbgCZwEF+lw+6jRekNAveyq/Q0r2DLtjrUKQAb5e1b3XGsLWPwcGJ3BJ/rvBYgHV9ioekysxBufDqIeGtVlMEntbuR/1GH6ckvz7hZ9SeEwM6BRvvSfV5mbaPiLILFM/qpHHeCu1S4/+XxoneEMHmsK7QMvM5WyfCWb0+nD038etfRKuVXPmU9aIM4ToIKRC/h7Q4ImzJRMVuTeDwRfd+ZtjMDq3Lqk8g1fMqNMq/JRKAF5zyqygQZ2a9aP/n0Z5fFQE9wsUupHA+pA8A/8xpGZ7GhtDq3lY0Qb6I+gQOSqyQM+NDdnGv7NMiYQjlifmnI,iv:9CqcKjav8jWa7oY0SK0xOi7JK6x/ICB1WqKcjv9ayuk=,tag:DgVlsei5TU79FZ62J7jJyA==,type:str]
-        key: ""
+        crt: ENC[AES256_GCM,data:p6aOz6e0kU+XnkoiuRTEZ9ufT0C+sTaqXghTt742ErJv62LwfmroCPbAKWxkxmXSpBRNQnIkei2vghDQiGfqretqSQDcA82eyeM0PbaHEyDm0D2rc1RwWTlQgO83THtPvhGEwfAwRu71UrbNRZJ34aaH6j0BKvMnKEdtbvwROAXAyhOW14XlenlBNYCCFqa13ri176lBCfiLd+fHzfUabyP+ed+mdi4TycE41QAWlQ4K62USXZVLNzihZNi3l9k+b+c6l1yaSk0IutQ0SKO+0WVzhrbK/kpGrMSrAcHA+O2mYvcUbC21atBd5ovOngljGEf9gje0cDfqU+2vHnnmvncYciB2/qNGZW78BcTIVuoX0aqZfIUnnvDD2vqGiqmzypdhdPdJW4O5ER3/3EE6U32/V/eIiOJ27mbQ0rGO+8j88sqNlQJf2OpjsmVli5J1+LFpGs/lzCurnjkxhFjCbhFcZt/8GCavvd8U4wSpgoalIAxZtPGDJ5iYspzogcrTMwFcvgJ44E3/zjYqBkJYs4JGUg4szC1kpjpwG49aefO6iiHc4z9lJw5MwRhvf7MB2kW487Prmi94B5lJaVKgInNtnEBtYD4+jsGyCJe5N8f/FzezHHks0C70lGkBfUiTADkG3PqBBh/rCYUZwQncyqZAgDITljSjPNvtBAXAlrw/eilWQzEwRdeUPOwApKsPBzoBCFfXznAphlPiAkYiGLYjzJ+UxoedlGLFXzcW0S/6dYnS1MKl9dWlIj3zWDwbX+beelPSs1RffKsT15Ovr6PxDqFNrg0YRTI5Sy7toB3E/EniQjeFA9NoFQKL8165erbtX4XYwGRMgDkuBJUTF6eevcLc11uD+FbQ/7Z4mzSEibN+,iv:XYR5pi0uiadlsMwTsNBEKQ3k4vsHCGIU5zW4zXJnnwY=,tag:+kCxTeCyfEE5nD7JIZx+Hg==,type:str]
+        key: ENC[AES256_GCM,data:3kBLQG8a3oXXGEU79Ojfac4vE5QzcU7uBoVgsKskvzE+E8WtOBCenHEaBHAIfHCZBxpVD0/vzmE7oNNqWaZnZ6SXAOksaQyYyNLfdnxGyBdo3oNNfZch4vdMBlbKYz+pNuB+KEaR53SaRZBYN2GWqMhL+hTekXNA0qZXUfGMewVmjwmTgZ99eb20GYVcTy5f71Q56vm7UAh+WvfUvu0OG/YWBTit9nzTu0YHSgBby4SGYGyk,iv:lXp2H9GEPmYcUEnn0nrA+rETUQF4X6AfxWm9X+3wOuk=,tag:x3lClvME05QYWKnjUTrATQ==,type:str]
     # Extra certificate subject alternative names for the machine's certificate.
     certSANs: []
     #   # Uncomment this to enable SANs.
@@ -21,7 +21,7 @@ machine:
     #   - 192.168.0.10
     # Used to provide additional options to the kubelet.
     kubelet:
-        # image: ghcr.io/siderolabs/kubelet:v1.30.1 # The `image` field is an optional reference to an alternative kubelet image.
+        #image: ghcr.io/siderolabs/kubelet:v1.30.1 # The `image` field is an optional reference to an alternative kubelet image.
         # Enable container runtime default Seccomp profile.
         defaultRuntimeSeccompProfileEnabled: true
         # The `nodeIP` field is used to configure `--node-ip` flag for the kubelet.
@@ -56,23 +56,23 @@ machine:
                 - bind
                 - rshared
                 - rw
-        # # The `extraConfig` field is used to provide kubelet configuration overrides.
-        # extraConfig:
-        #     serverTLSBootstrap: true
-        # # The `KubeletCredentialProviderConfig` field is used to provide kubelet credential configuration.
-        # credentialProviderConfig:
-        #     apiVersion: kubelet.config.k8s.io/v1
-        #     kind: CredentialProviderConfig
-        #     providers:
-        #         - apiVersion: credentialprovider.kubelet.k8s.io/v1
-        #           defaultCacheDuration: 12h
-        #           matchImages:
-        #             - '*.dkr.ecr.*.amazonaws.com'
-        #             - '*.dkr.ecr.*.amazonaws.com.cn'
-        #             - '*.dkr.ecr-fips.*.amazonaws.com'
-        #             - '*.dkr.ecr.us-iso-east-1.c2s.ic.gov'
-        #             - '*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov'
-        #           name: ecr-credential-provider
+                # # The `extraConfig` field is used to provide kubelet configuration overrides.
+                # extraConfig:
+                #     serverTLSBootstrap: true
+                # # The `KubeletCredentialProviderConfig` field is used to provide kubelet credential configuration.
+                # credentialProviderConfig:
+                #     apiVersion: kubelet.config.k8s.io/v1
+                #     kind: CredentialProviderConfig
+                #     providers:
+                #         - apiVersion: credentialprovider.kubelet.k8s.io/v1
+                #           defaultCacheDuration: 12h
+                #           matchImages:
+                #             - '*.dkr.ecr.*.amazonaws.com'
+                #             - '*.dkr.ecr.*.amazonaws.com.cn'
+                #             - '*.dkr.ecr-fips.*.amazonaws.com'
+                #             - '*.dkr.ecr.us-iso-east-1.c2s.ic.gov'
+                #             - '*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov'
+                #           name: ecr-credential-provider
     # Provides machine specific network configuration options.
     network: {}
     # # `interfaces` is used to define the network interface configuration.
@@ -174,7 +174,10 @@ machine:
         # The disk used for installations.
         disk: /dev/nvme0n1
         # Allows for supplying the image used to perform the installation.
-        image: ghcr.io/siderolabs/installer:v1.7.6
+        # Talos image factory generated link with following extensions:
+        # - iscsi-tools
+        # - util-linux-tools
+        image: factory.talos.dev/installer/613e1592b2da41ae5e265e8789429f22e121aab91cb4deb6bc3c0b6262961245:v1.7.7
         # Indicates if the installation disk should be wiped at installation time.
         wipe: false
         # # Look up disk using disk attributes like model, size, serial and others.
@@ -189,6 +192,9 @@ machine:
         # # Allows for supplying additional system extension images to install on top of base Talos image.
         # extensions:
         #     - image: ghcr.io/siderolabs/gvisor:20220117.0-v1.0.0 # System extension image.
+        extensions:
+            - image: ghcr.io/siderolabs/iscsi-tools:v0.1.5
+            - image: ghcr.io/siderolabs/util-linux-tools:2.40.2
     # Used to configure the machine's container image registry mirrors.
     registries: {}
     # # Specifies mirror configuration for each registry host namespace.
@@ -364,13 +370,15 @@ machine:
 # Provides cluster specific configuration options.
 cluster:
     # Globally unique identifier for this cluster (base64 encoded random 32 bytes).
-    id: ENC[AES256_GCM,data:ociWLZu/GBfPnVkkqgN+pttkDSStoH93NBp4C1RhMzGfn6EozCTS7vwJGVQ=,iv:pp64AV+Z0J6SPg5yp0ADg51nwlgdQMA1+JWBJGut0+s=,tag:d3p+TLW+6NpCsdx1gcGwAA==,type:str]
+    id: ENC[AES256_GCM,data:Zy1xsEv7invBvKUSFSU38cCmEN2crlG+cDITEOrLEaCjbXFobUmK1TMwgW0=,iv:3dw1M/lnH7Xa+LYKlmE0w8zLI5aOMTq1MuLsAFEYfgA=,tag:hzaGkMpq8NkECCt2SRq0sQ==,type:str]
     # Shared secret of cluster (base64 encoded random 32 bytes).
-    secret: ENC[AES256_GCM,data:sBZ3PSMoiaSy+iuVRgoP08no43JJeRZ/nMISZ92T05XudCU/wVp33UkWvu4=,iv:w+Cgb3mUHDiFu8tOVS09XZaSBCWutO2f9G3zjBIXXGQ=,tag:mZcMCBLRf9INvuHvjkRupg==,type:str]
+    secret: ENC[AES256_GCM,data:ztSFN/UV/WGmrTJiRaDb8BVL5d74q1CKmNhiq/2VfMWYIQagj3p6wi/4OMY=,iv:ViwqzdeGxX7jVY/Y2RBDM4OiGKOi5Vgbyue15I8Oizg=,tag:XjjguwjNrWp07SY/+iB6+Q==,type:str]
     # Provides control plane specific configuration options.
     controlPlane:
         # Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.
         endpoint: https://btrkube.menia.cc:6443
+    # Configures the cluster's name.
+    clusterName: btrkube
     # Provides cluster specific network configuration options.
     network:
         # The CNI used.
@@ -386,17 +394,69 @@ cluster:
         serviceSubnets:
             - 10.96.0.0/12
     # The [bootstrap token](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/) used to join the cluster.
-    token: ENC[AES256_GCM,data:+6jzDeEgqmOd2WrwcF6ZsgF0y1d/0+M=,iv:CXcI1AdOxH0i5cGz96hQ0W7vNLCB9EkD3vkpEEgnmDY=,tag:qwkFd0V4x6J0YhPUvAJ1jw==,type:str]
+    token: ENC[AES256_GCM,data:ML9n4fHKMOPfkJRKBTLJPL0Sk/hmpWQ=,iv:VtQ+dPg4dyHUUMsYVsinTvMjbwKgp6Kwu0moC60M338=,tag:xL3t9BW1cW9JY0QK29gSnQ==,type:str]
+    # A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+    secretboxEncryptionSecret: ENC[AES256_GCM,data:ODj0ic0/yeycglsw4S+LudC/t+K2sVY4K+bxg7kvNsdFC1Gttipg4sWZLxQ=,iv:RSl2WQf75/1Qf8zrEUPv447gQv2mfQcaXWJppAKlbhA=,tag:zpmOM3mRWRdafVEiUQV1aA==,type:str]
     # The base64 encoded root certificate authority used by Kubernetes.
     ca:
-        crt: ENC[AES256_GCM,data:0NoY0UwtalW1pqUlUd9MQW8fKVPnxEbIK0S1TZOi0+Med35MayvgAFyMDOR0mPJWwfq60/KTWmsGor50ssWreL5XdvNd182CrtUjeM082XE+RCzxJ2BFPaHL+V46QwDQCop8p9dp3lkwh1XH3/DHAeKVzbgvFHo0DJoUqnZ5Gi1gR+zbgQ3f9dpF6ygPRzcPn94qzWoq8Rj7YZVvAnyejQoX6pZhhvrowtIFjmmUj3EfsVXzTwO0k3K70L+CyUxb5teUJaU8Ui68vtUVSDlxAP3S9J4ha7jjvqfCN1xXViSGR2NwqHLEzPYoyJCekZlxSyPnVPzktZUwGG6KVtiIL+0LF5GdmPrBTeTC5rHVaCHCCuUBCjH9LzbVoPWOh5vz+a8gGMNdhB0O4izy/dQIbVKhHexMtS64SkmyqwHj7nqP0prrVN7H3OuWuMsWjIZuOrzTo9DaAZBitgLzYEMIc2fgsUftpNSgoTBHYM1VM7rjSA6eiW8sFSfHiWQCOYEXoRjB9fig1AR/YqDA/FwEYxD5ivqplAH2BYWk8SaeApC8cTFI+NYk7/XeAvC5Nlpq6btiRzv/segRLpPSw55mB0VhnqNggeY3SWTP3fn9CkXFV1rU6F7kL2shTa/G4tKpzasV2sxs5cZjWhdjlUrc0juGx7bMxPDo+/Rk5etHcEC6zPjKpyqXzSd+RiQTZmXpx6r7Kt8nSwG1CIA9tLQPUaYzfFjoWlUVXBKFo5b7E0ropfaUIHkQK3zRlFyzAzlstx0UyQAKwY8pD+5Hv2h+9bPiI4MuEqwhFTa5hhf/nABlOWb5U79DleykUrXXEtskChHvDWdIlbhat/sIRncYUcO6mbrcvhYEYCRUfWdZ7bMM1OfQ5Dekn0Fop0rnL1CpCvssy49Uv7E6L79NaeWOFALwuWdyLSLbYQbwjNFDTugeBqX4VPluh5PRPJ0fTL0LIq7U3+XGyPmiOGb0x2s625ejeUNMTFvAkFaZhHW8quW03z1Z1P0qzzPMk43S10vSC0qbp8AoBzUDq1xWy456JtdJQLIWC3fboIRNFA==,iv:fwjs92rJF7YamSg2HjyMUnNqopV+5t4GxJrnsLhH0Bg=,tag:6CEdfdKEMoAXoG0036Y4hw==,type:str]
-        key: ""
+        crt: ENC[AES256_GCM,data:l2VPCWr0E86IQa+K6snptAAiZFaHXs8M6yph/Gz12MElWD/9fqBvAngKuYXat3Riubnu4XPRA4g3p9CDPVngm1gdZ+XReu3co/CN9JzJjQ0Ut5E7KggZ6taSLGLWBaSYTvbY8X8EnHdhzdnCrCWgeGOe1fed6GOpIe+/7yO2fEceMGaQ7xbHs1ozDmiJUcDrp4/He4eLW1AIphWTe8RPvDcix21mYxCOxy/bWMsJgwhwARugBuJAclNjYmeErIT02xAC0q85ub+2w55oVkal0A1lC9Gq5B6FsckjkwbvxPxQvf7X/g6LDcFBdcL2IKQ3CkSgXTalC+6bCY7P6u5tV8UOuMZyxcgkDjw3ZHkPrubTIkErJfK/flmClOosFAEaA7Ylfnht4OlQD5SsDJ2Up6irlJZ/vqEc0Qjp2LgvW2aMxPokUmhSroCRZhMI88c9PyYfeND3r4141BUq9tQwZVpBFpDSS3qu6QcgR1BIIZw6o+eDjv7ZA0CL0slrb4gc5lXomVDnJ6cFIm+m+UJ9gX4Xq5axTkV4b9Wd4zRrQMs4DIn6FHU1ml5fNCIKXQcUfcvt7U8g7zlrh+SyGXIcsv8EPzvpNUSu7jQB//FWEFNC+FZNArd+BGmRjIGXBDPcmltARnsYLIbl+FFIyWLHgVmfsG3YVhiJCASO7CaGB7jqAmKanTxIUJ7YDAh1gDS34CEHrSRc0bm0vwA2bIuuXsrsWcOwdOTq2TeskDseOzWNdDypyHt5oQMyTYW8gXzIXhnWfonyODS3U6AOyt/Gw31+TNTRFXVbSGVwB+CGDj+irLJvL9JqZKbsJlhN+XwmYjPCyCjF5Xkrq5XU6/ZoMM2M8BhNZ1iq3zCFPrN2y6FALsM7a2+B5ZI2aA2YWpquXSt5KrrAlpJlRQ58SKOknDvtfHdTYaeViT3aP/X/PHnKq0IgC+qa4jYUp9X65P1nVIM80IgJDtXoFfvBpyKotx1ACht1nCHrZJuaf9T1BSp4uArmb9P0sub0+wlOEefcwsy+cvcYXWQlkB0ev6lzUMNiVXk4QDbz68DYOA==,iv:Bt/izlq+w6m5NOL+zUeBae+f/X98N8hI6XzELqK5OGU=,tag:ofRumZFd0wqN+gtw9tM3xg==,type:str]
+        key: ENC[AES256_GCM,data:rfP37YkC8eP3CTb6qbvlRDgGfjILZcgtS1hL7fu/0MC0NyvLwojl22OPSYn+LLLarjYHYKUy0b6n1fYvhrf/JkVAkM6hzGHfn145CSJp2Ak1RJ6wo6NWpHpkpc665bHIDgyFly2HzLMmZRngJ+w65hSJkvPsvWTOKLZMNnWp8NKWREVzLQZYYp59ERW/ch2s0wwwaeaJ418Mmg13ADhvtmhufGob3P7gqhXVApAjewHQ/7/fM23uRGsd6ACSyxqoz9EEqHRNjLldxcFMyYn9R5R9ZfPHSerHXHyfsdGWobT8kVMrGM/Mvc8hwYPFjRcKo7PNTQdssoHzuJJSgfgVl2x5O0mQ3dJjmDZvVp8sTUJxbEcp3PoAPD1zxbPNsHMbW1T+eIkOPfaj+ExyN5qcUA==,iv:HLfzsfja7979/r+AwjGJl1A5h9Tl1J3RuYVV0CsfODY=,tag:wDi1Snoy8e1QFDHRjRigGQ==,type:str]
+    # The base64 encoded aggregator certificate authority used by Kubernetes for front-proxy certificate generation.
+    aggregatorCA:
+        crt: ENC[AES256_GCM,data:NOwpmUrk40jR8fp+9LsEieAQc+uHpeNlhbW2LQ96yUE074UGWHa6x0hYsPPDHNJSmi1bXDr/Vd8Ln5ceKdG58uoPub8vUn8N1iUeimCIMyP+Rfyw55bKaqqUv97HyLvFGAGpoor9GSJcTxkZJldNi2e+vzlczwheax+83JvlCizdFo3eGuOqZDc5Al4dfMx/RztjoTq+wMW3qGM73gkX4Xoj54nKakzJEQCKj9xwdW7+herQUUl5Hd2FwTWd+iu/HClNTO7lUD9+sTyiA6d7tXs42VlCaTQMgkf0/lTGUA6vt047Eh9V4w70K3ZetbUzNjGnVJUmwaEMt81CIStOF6b2iEFRsLSBvnOOz6ye0M2Sjr+o2u8bu1p15i9WCReNtb4i9bNnQ1YevWSJjiBkGp1/wJfapmiq0Naj8Lr8rUW26o8sv0Q+WxRQ1Pl32XlrE3yRidz7kyGCaoUTKzK90a58YyJm6wvcmZUhqpijorIarrh8+fWER4JD/avqkE3LBEsnx6puDU2poJkcp7J7uQQ6h8w2mccEw+EZskZo1kJWPd9w/V5Ddgxp/gHeLsKgZmjbS3afBRgaT5xEKfZ83ETnyeI96sMeflOgegHR7NgnChuW+BDEMDSCEgLvVUDOfA7GqUdHDwW7cqdFlphW9Dyu+ekra/kLwJFOkoNy7cBuw9UYLgISCCUbrSRrIBb/QYfFFu3K+lHAjursGH3AAFX68Xxe2RREzGnUsLPJe9cW3acwOUAQ5lCxJ8ngKCGvbD2HI+yVQWwbTcWtwaN1QszUz2nfG4FXilqmL+JNQ6S1TB4MWnZc3cCte4hrr+D8jFBaRGpTlUKgy2JDb5tu9g5CfTM7vjvKMZqkQDJlWmzHRNfgEFdioOa/HfR9Au9WCmtkOmSJuiQojwLVJOlLUb86lnxAOXvVGu6gPfiJrP7vmd1Z9kaHBjXPWZ7FUrji,iv:6xRQAVSiSM3YrDOc/acvfEuJMbW57ej5jUuJpkGChJ0=,tag:mviUo1nr/2zx25IUjoWYjw==,type:str]
+        key: ENC[AES256_GCM,data:+6UMZOSoiIt/X+4MbOQoZ6qg/bj9sIgDfQTk2Z0R4KXnd8Gb/0OaS84a24AysnAHljgwdvk/1ZeP1eRKMo06axNi+LJl8qBB4xPt2aGlLSAjXrcH0Gj3ZTXqWKAmkSXH8JywljpplCIBMTfbI5SoQBFBuEOpAy3nEdYW6uHLqi+++/EoinuzNSW7lWolgZM8iR+Ja7p/dWgAwAYwdZgKs5GG1/KFsxvclGIIJfAOW0Uz34SWX9YhGvVrnlsuzbxDDNGUw6OVhEinfg2OicQH9BJB5jOnrXpl0hnM8n4BA9LreqmHUuwr5BcN4jieqOua7Arg7NZcB3F0M4OB+v/RlVjarXM3oVKURLjK4mZ17c1WgRVEzMF+8s6PX/SxK117xhsWfhTJjVAPWHiEnTlldg==,iv:8m9xaJNPcY52Vsgok0Ctvb3O3STo+e67HyZopIRbX2o=,tag:biuONMxAfKzsZU7H0Fypng==,type:str]
+    # The base64 encoded private key for service account token generation.
+    serviceAccount:
+        key: ENC[AES256_GCM,data:mBM41HwjTqH327qbssVmJazGZsoQ0o+4lHdHTIS4NOyJMDFbtN54XutXmdjs1mF7LGBUt+tsXP4qH1rkdwLRcpfmhpbBX3FHoybKKJaOidIMarCcST+NRxDXKhDZvOXmgeLMVnVvor7xDrhK8lmHkr6PrMUWHlPjhzS0fqDWUmBXqTAtbINIVXeMcKZi+Vly9ufqQeKzoqjJc1gm6BX/JCdqGiSHwSnWhBdwGVWLczK43J3qrDiHEurUKcBf9Q+eQCfBp8yXRs2Wr4EiKrldz7KiwjGdG5Bbei07hZFxASEf3do5zZzR9fRMOpabWcSKuhiHcqVhX09j0yyPnWFxxseDJooPfIuzteLcPXyG9PcYgLdOvazWePinlB9mPSaHNGOS6+2udChUrKGwS8e5FA==,iv:SPP3dfbbTob+oidnviW11/NOr4xc4pHd+/NibbhAYeA=,tag:GOug6oc28n5t6LZmjH9tuA==,type:str]
+    # API server specific configuration options.
+    apiServer:
+        # The container image used in the API server manifest.
+        image: registry.k8s.io/kube-apiserver:v1.30.1
+        # Extra certificate subject alternative names for the API server's certificate.
+        certSANs:
+            - btrkube.menia.cc
+        # Disable PodSecurityPolicy in the API server and default manifests.
+        disablePodSecurityPolicy: true
+        # Configure the API server admission plugins.
+        admissionControl:
+            # Name is the name of the admission controller.
+            - name: PodSecurity
+              # Configuration is an embedded configuration object to be used as the plugin's
+              configuration:
+                apiVersion: pod-security.admission.config.k8s.io/v1alpha1
+                defaults:
+                    audit: restricted
+                    audit-version: latest
+                    enforce: baseline
+                    enforce-version: latest
+                    warn: restricted
+                    warn-version: latest
+                exemptions:
+                    namespaces:
+                        - kube-system
+                    runtimeClasses: []
+                    usernames: []
+                kind: PodSecurityConfiguration
+        # Configure the API server audit policy.
+        auditPolicy:
+            apiVersion: audit.k8s.io/v1
+            kind: Policy
+            rules:
+                - level: Metadata
+    # Controller manager server specific configuration options.
+    controllerManager:
+        # The container image used in the controller manager manifest.
+        image: registry.k8s.io/kube-controller-manager:v1.30.1
     # Kube-proxy server-specific configuration options
     proxy:
         # Disable kube-proxy deployment on cluster bootstrap.
         disabled: true
-        # # The container image used in the kube-proxy manifest.
-        # image: registry.k8s.io/kube-proxy:v1.30.1
+        # The container image used in the kube-proxy manifest.
+        image: registry.k8s.io/kube-proxy:v1.30.1
+    # Scheduler server specific configuration options.
+    scheduler:
+        # The container image used in the scheduler manifest.
+        image: registry.k8s.io/kube-scheduler:v1.30.1
     # Configures cluster member discovery.
     discovery:
         # Enable the cluster membership discovery feature.
@@ -411,82 +471,32 @@ cluster:
             service: {}
             # # External service endpoint.
             # endpoint: https://discovery.talos.dev/
+    # Etcd specific configuration options.
+    etcd:
+        # The `ca` is the root certificate authority of the PKI.
+        ca:
+            crt: ENC[AES256_GCM,data:4CY9uT+P4NTlScQscfeb5NYcmv+YmrWCDX5BHJ/U2ScWaeyyji2cD/vGixRd7HKsUna+lMIylNm5bMEjruCCzXihlhXDVGKvWjGNJfkl1M1RNEdL6rbmd+uqtH+sWX1a/18V8BX6glbHy/Ybhagyed3qN3GhgDPiL2id+W8xAXvEuvFVibOZ+l/YzUzu/Q43g4pN9wYhr2vutiMAiYjObJ45n6HGcrB+iDaV08agV/S5baBguOGAW80FzxJ4weCA4tDaCTBsHiWQOWagzGNhPJ4NXltA02eRsiZCqOuXucqTUzSPkAfTZmCGVY1aSZ9xoaVYweFWwwnNUKZAWE3WYs17ekOySMs5R0SVALbJFvJHv0gRUpBdWS60wirxBxx76Cs0KkJAXVqEQZnt1aU21zDsu6mhFLQjQXMbAIir6+8TYBydtnO0cYMXvsa9F9UR0ipOorXw+00LSOULHw78IiDQuSNnLa1qMrjdALhcFDNLIhqf6zffKmkpFn2ZJf2XmMk4kPVaSMoba9JLAGVq5QOEECXGJSp42LHJVuyDKSC1tcksrATW8kXIVYYZbyyCL/uBgoMhuN2RVp+1mzA2owssC0iDDT724ohQuXrUSHZg0CNAm2bWRv1pSmI4hihd+tYufzBRnNWd+yYdtDGyTwsihheScwr7sj/Yg5Rlu5uRnzVJb+odyHpAMJNligYi9+I7+Ff5uL0mh31N7+h6MOW4DJ9s+DVnyj7cSzGlj8MB5bvehidviT+A/iDhuP5KusQkwTKdx696u/nSQL9vBJ9mNpB9Dv7Xk38JlEEmMHyg9ZxHrXNSAUKgQ7qB174REkgrucqU/iNul2saBJSAzjycbWOQ/RfAaTWrB9J/oKdmzDZWTVhYWtfQQkXKjJ8fOVjlebF9bNm4dCIGnbG3pmDzEBJZ3IGDEwxgFq+R7pZyX7BkSKTSDwUm958oChklC5taaFNgnce1kVNot5AVilzYYY2eKWCJ67ruNzOQ3x2eCGx9pB376s7aSuBGUcpDFtQDNw==,iv:0Qujp95RZ/NkjK51Jb4YyqOlvMEQBJ7EQoof0kYqBVw=,tag:m7XGB3hB6ppK/iQA3zGcDw==,type:str]
+            key: ENC[AES256_GCM,data:1ifOjHT0fujebqF+N+9fTHaF6vCA11srKpGl3GmYHbmgDA/N2aCW3Z9e0c5rIP9EfxCA3Uig+5bO1DUtXCCbnO9F1MhoVdbYeqGSZOMln0u+ClJyHBYVnrILQDmiqdz2cdNWhSVLbr0Oih1DaogZPJP4dQOG9tsMwqDJE6pEhNWD28h2NUBi/fcGQ8mQp70JIdAMEn/fVbn1LS7sLVnn4+nkZc60V54oCc8eRlOCw2vXG/npzmE7npsulq0Gz4OOiM65CN9LwZRTrcZrP3VgFlsf3f+n0yRGwHUcW7YLC62/oATVcWrLc1pcHvGH4vjQcJNdB2s+OYUB9hJIsqq0QnjN9y0et1yrv1JNEb9FwnDfsM4lyXx04HWM+AkaXn0wC8z51/DyyLk+X6l1fCLJqQ==,iv:L9M5podp2AyfnyHhQZVHYHoZjzl4aI9T8rbUBoxx/fA=,tag:Ub4ErxN0zmXwWV6Y30ggCQ==,type:str]
+            #ENC[AES256_GCM,data:u7+6CaW8xQn/DwNWGpUcl3MAMIJL4QMh6nWXksU0ivQm618+l9AU8GhwNl6HcECLhEIsq2b5RA==,iv:vqC54gJcrfvOw3oTWYM1zwdGJsmRqPqkQp1LixMbYxg=,tag:LMQsYV4fLOCc7+hAlrJzQA==,type:comment]
+            #ENC[AES256_GCM,data:kX95gAL4rzOgspKfHcSl3u4QojbMnosLH+5UIodxnNKU4hkR7TAsJoElDH7vZa4ENcY=,iv:R1PNrKkzQjDrmGoUJy/zO7Z6DB5nNGpkQfwvfRquQZs=,tag:aQz7guqkCUvxHijBbjNd1w==,type:comment]
+            #ENC[AES256_GCM,data:Rw2/VEmSqx5WReyNdsB4GjzBYd8Q2xq0USIWxpZSBwusWN5NkncfuQtbzvNP0rGKAm+70cjNEJsYaS31MJkeAKR/ZbVI3q1EpG+MWI5ED7kN7ZPSpICZjfg=,iv:dzSlT0KFxTfTRXZFK2hPnUUrkawGspTOMmlVomm7DGg=,tag:jcG8/iRFlwwnCn9PD4z3IQ==,type:comment]
+            #ENC[AES256_GCM,data:3SsMNS0Gu3IGMlYKt6l6X/1Scw==,iv:HVjCzlIXrWvu56Pw+uRhk0YbV5cYeqalw3RfW8s/ZDM=,tag:jhYxe8Nn/eLFHJ8BZJOa0w==,type:comment]
+            #ENC[AES256_GCM,data:2VeQrn4OrxemnROwOXHENV8=,iv:EEoJ3VPCl63M+/xPy+K0HTY3EkjivYg83n3cU0pQ3JQ=,tag:KLnrIYlEewvBwkX/s5P/WA==,type:comment]
+    # A list of urls that point to additional manifests.
+    extraManifests: []
+    #   - https://www.example.com/manifest1.yaml
+    #   - https://www.example.com/manifest2.yaml
+    # A list of inline Kubernetes manifests.
+    inlineManifests: []
+    #   - name: namespace-ci # Name of the manifest.
+    #     contents: |- # Manifest contents as a string.
+    #       apiVersion: v1
+    #       kind: Namespace
+    #       metadata:
+    #       	name: ci
 # # A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
 # # Decryption secret example (do not use in production!).
 # aescbcEncryptionSecret: z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=
-# # A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
-# # Decryption secret example (do not use in production!).
-# secretboxEncryptionSecret: z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=
-# # The base64 encoded aggregator certificate authority used by Kubernetes for front-proxy certificate generation.
-# # AggregatorCA example.
-# aggregatorCA:
-#     crt: LS0tIEVYQU1QTEUgQ0VSVElGSUNBVEUgLS0t
-#     key: LS0tIEVYQU1QTEUgS0VZIC0tLQ==
-# # The base64 encoded private key for service account token generation.
-# # AggregatorCA example.
-# serviceAccount:
-#     key: LS0tIEVYQU1QTEUgS0VZIC0tLQ==
-# # API server specific configuration options.
-# apiServer:
-#     image: registry.k8s.io/kube-apiserver:v1.30.1 # The container image used in the API server manifest.
-#     # Extra arguments to supply to the API server.
-#     extraArgs:
-#         feature-gates: ServerSideApply=true
-#         http2-max-streams-per-connection: "32"
-#     # Extra certificate subject alternative names for the API server's certificate.
-#     certSANs:
-#         - 1.2.3.4
-#         - 4.5.6.7
-#     # Configure the API server admission plugins.
-#     admissionControl:
-#         - name: PodSecurity # Name is the name of the admission controller.
-#           # Configuration is an embedded configuration object to be used as the plugin's
-#           configuration:
-#             apiVersion: pod-security.admission.config.k8s.io/v1alpha1
-#             defaults:
-#                 audit: restricted
-#                 audit-version: latest
-#                 enforce: baseline
-#                 enforce-version: latest
-#                 warn: restricted
-#                 warn-version: latest
-#             exemptions:
-#                 namespaces:
-#                     - kube-system
-#                 runtimeClasses: []
-#                 usernames: []
-#             kind: PodSecurityConfiguration
-#     # Configure the API server audit policy.
-#     auditPolicy:
-#         apiVersion: audit.k8s.io/v1
-#         kind: Policy
-#         rules:
-#             - level: Metadata
-# # Controller manager server specific configuration options.
-# controllerManager:
-#     image: registry.k8s.io/kube-controller-manager:v1.30.1 # The container image used in the controller manager manifest.
-#     # Extra arguments to supply to the controller manager.
-#     extraArgs:
-#         feature-gates: ServerSideApply=true
-# # Scheduler server specific configuration options.
-# scheduler:
-#     image: registry.k8s.io/kube-scheduler:v1.30.0 # The container image used in the scheduler manifest.
-#     # Extra arguments to supply to the scheduler.
-#     extraArgs:
-#         feature-gates: AllBeta=true
-# # Etcd specific configuration options.
-# etcd:
-#     image: gcr.io/etcd-development/etcd:v3.5.11-arm64 # The container image used to create the etcd service.
-#     # The `ca` is the root certificate authority of the PKI.
-#     ca:
-#         crt: LS0tIEVYQU1QTEUgQ0VSVElGSUNBVEUgLS0t
-#         key: LS0tIEVYQU1QTEUgS0VZIC0tLQ==
-#     # Extra arguments to supply to etcd.
-#     extraArgs:
-#         election-timeout: "5000"
-#     # The `advertisedSubnets` field configures the networks to pick etcd advertised IP from.
-#     advertisedSubnets:
-#         - 10.0.0.0/8
 # # Core DNS specific configuration options.
 # coreDNS:
 #     image: registry.k8s.io/coredns/coredns:v1.11.1 # The `image` field is an override to the default coredns image.
@@ -497,22 +507,10 @@ cluster:
 #     manifests:
 #         - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/rbac.yaml
 #         - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/aws-cloud-controller-manager-daemonset.yaml
-# # A list of urls that point to additional manifests.
-# extraManifests:
-#     - https://www.example.com/manifest1.yaml
-#     - https://www.example.com/manifest2.yaml
 # # A map of key value pairs that will be added while fetching the extraManifests.
 # extraManifestHeaders:
 #     Token: "1234567"
 #     X-ExtraInfo: info
-# # A list of inline Kubernetes manifests.
-# inlineManifests:
-#     - name: namespace-ci # Name of the manifest.
-#       contents: |- # Manifest contents as a string.
-#         apiVersion: v1
-#         kind: Namespace
-#         metadata:
-#         	name: ci
 # # Settings for admin kubeconfig generation.
 # adminKubeconfig:
 #     certLifetime: 1h0m0s # Admin kubeconfig certificate lifetime (default is 1 year).
@@ -527,14 +525,23 @@ sops:
         - recipient: age1ngkdczpldhxhx8qchl0v7c9eq06vnc5yea3mhsuy0n20hvyescpqv3w2xy
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRY1ZmZm1QVmZwSGlZUkxD
-            OVVrRHdGN1VxM05adzF1ZW85N1JmbGI2Tml3CkNIU1hGd2kzeUVUSFUrZkpaZUJn
-            czhUTFVhdUNFejdURVluMWxCazhoSEEKLS0tIDdXYlBrQkF6VlFuOEhHbFRDL285
-            Y1k2amVVMFBDSHRvekZrOEl6NytDVUEKyVNsHhQC/YVLVT3LTvdMVT8NabS51tZn
-            aDuJR/XqSfnSHBVTBaawD/It0NZKWoPC/pNUna3jMqT9jY+Y8FWBEg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQQjhtM1NPamk1OXdwdGE5
+            UWV3T05NWVRLREwya2tSOCtHd1h6dml1bFVjCk8vNTY1OEs2UHM4cmthaWlGZlg2
+            NmZ4bFQ2c3UyYTFmK0h4dDdNa3phR0kKLS0tIEJtV29yNHozNlJFRHNmZVRFWkFi
+            bFgyMmZUQjk4ems3M1lOcytidUdrUkkKk0hjHaI2seXieezyNpewQ7i1sLZnL+DC
+            1VwQRaiO1mC0/Z5sqICktJDgVYyx+1L1vTR5hClhwsr5TyYqoXucbA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-05-23T02:40:29Z"
-    mac: ENC[AES256_GCM,data:H6TRCWGDKKDkK6AXhRCdYNJJ0GglG6MCJ3PuKorw5zEKPJZlM87nDCGrj1wtlZz6PQHw9Vv0dmF6VrUpBQGQqVkFvXvZW5dgrh/a6n8vJy6MKV+JqoJzav1L1QBiRam1dvK3JGQU+eAWaWbFCNg/bqZNVeYtbKLspyA5VpDmKBo=,iv:tskML0vzi/vYt4I5GJCpvp2BUJLQTYooF6KdkgvtRFo=,tag:do6Szsad98TOlR0zZIt1Nw==,type:str]
+        - recipient: age1xzxw8fsvdz53aa3r8z6t4zns2cqadjm4ep88w5jf4zw3yhcflvesxgkxlc
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWRjdFdFMrUHhiZlNBK0Vx
+            TkJGTHZvRFNaWDZENjZJc1g0THluSW5ONXhJCm1idC8reVRYbHZvdkp5S2xTVXUr
+            VFFJSlhGcmgyaGttRGRGcjh5OXVrak0KLS0tIFJVYlNxWWI1UzJjS2swMEdtTnc5
+            dXd2dnVaS29CS3hNb3p5dWdmQ1BLaHcKwLPI9qRiB2mdBp3H/ZwlZya+pbz9MKCe
+            v8cd2yc34oM1wV1cqnGDtmGjqAXg1AgCHlei2k9s3o6J6aZsW5pdUg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-10-14T15:04:20Z"
+    mac: ENC[AES256_GCM,data:jEMHz2TOk2d++aGTFeIUNJh21rq7AOGhGFWoqWwxXFtzi0r1+mxDWOIT2NX69jacKEcOL8pqnAXaHpVk1YWl5vDaxZ0Ak9HH2daOyPsebTfwQ4fEb1TWkM1REUmvpo20o8UiihAZulp6t6/ukO8cN/0LfKzSF8VvO2oGngrJlB4=,iv:FZooYgwcd48itIvBB5DeFA3UOI4rUB6cu72+MmfozPI=,tag:b0kfnA761bK8UaeCEKq3ag==,type:str]
     pgp: []
-    encrypted_regex: ^(data|stringData|ca|crt|key|id|secret|token|aggregatorCA|serviceAccount|bootstraptoken|secretboxencryptionsecret|secretboxEncryptionSecret)$
-    version: 3.8.1
+    encrypted_regex: ^(data|stringData|ca|crt|key|id|secret|token|aggregatorCA|serviceAccount|bootstraptoken|secretboxencryptionsecret|secretboxEncryptionSecret|clientSecret|clientId)$
+    version: 3.9.1

--- a/infra/worker.enc.yaml
+++ b/infra/worker.enc.yaml
@@ -6,13 +6,13 @@ persist: true
 # Provides machine specific configuration options.
 machine:
     # Defines the role of the machine within the cluster.
-    type: controlplane
+    type: worker
     # The `token` is used by a machine to join the PKI of the cluster.
-    token: ENC[AES256_GCM,data:RmRZVUdnYdvQbuTq8GOH4LXT93qUFvk=,iv:ii3V+O2Q/z4Vr2OXeJfhL591RnXwx9qguvKhqJx/S8s=,tag:wYwP5t7BGTX7oFE+a+76Tg==,type:str]
+    token: ENC[AES256_GCM,data:9fILOi7I3/yNKrxCi4bS7yTB8TOrUQE=,iv:wrnyejzqedfWWGH+qmvwgl8mBsOEOIoMoEJGCpgH17k=,tag:81AzO+XranVFqhzwKIrr8w==,type:str]
     # The root certificate authority of the PKI.
     ca:
-        crt: ENC[AES256_GCM,data:s7eu/OwafBlNSziq4AekUnjUl4T2J1rJuLrwOlgZdsrhSRdH2MSD+shR9rRBR461YNgg1TaFqayi00rUCiB2lC7Al1xbdvzVbSNtQqoWOI8NS8GUVCfPE57/pgqmWy4tAToeFCg/N+wkOdrVlJypR4y3ed6jgVD9DDLxyPQQ+SkqkeRLpoTDSjFZWJHDFCo3nxE9nSHd2KK0Hsuk96o0/mrxbV5l99z2fWcMP+5KijOT0GpOVrDy3weukb1zXjPJbXif07bMfMWlS3ZykIE6i7tIgAB4m3IlZ+TobnxAoxXKmrwNqbjdqe3rViRHkbOrAlmmdRU1+Cm0W760oUnbtH7u8sx7th/lm491UMzTbrvtlsOhfOU92/lOGPw2szwsF9qurOwqrwFgjjGGcBTBJodLrbv4kkKWlfUfk1CGBVCBHMbYssfbJ4gHn0hhAHgIr93e/HV+U2SDJY0WUskE1PI5VE8CxeHGVRa2r0M65Oz5HUeQmKQJHDuidCSNDjfr9hP+FOiYqgRCsR91+QL5/EpPSUiRZxQPLhKTCdHMBLGbRS5omIpYoaWMIwGVlMWAblAj2mKBdlWf6ScRB4y8QKxrIufzTpfBpZV8ngdoIcgwWmhLh0fLEWatpGfTEMWTuVAmu3dWM3rpTyjROQKlzfPdmP7aNl95sLHxUTiZxPK7+vp6PPfTPdn2vZTC4Uwu61lNXNdezGvQQ5ednptmDYjfVQF7Da43GqUpz7Kzqt5Z2R3Mn744lEe1QkbH3WbIb7GZLAnj3YHRVSnpZ9Ob342fF8LN69tiZqBbfPnUnpF8IozPrzYJSscMYpGCRuixNx8ZUTvUxDeKf3TbWr8vMrYf2Xam8z8GRXw3ij8ZtbSPEPup,iv:3v+RDKWN9B7kVfkAWmyUjn2UQHBVCpOGk0uys5w5s5w=,tag:X8V2f3dka7KTdGYq8r2t5w==,type:str]
-        key: ENC[AES256_GCM,data:eREa/gYrrhOWIsUQ9XtcuzrLaCVcoAt60wauwRZhsIAjmAoq4GHd+xprHpylm5WNxcQzLWltk8whlcwPZ4WNPBdQ1D8nYJGw+eh3ZkNvHLkDkO463NpEIX69UH3w0p1wUUeBnTveFqvU/YPyih5iELBmO7DnSmcZ7k4ZbiPN4UjgOsAlv8/xZwZznRgjxlXV7KTMyASA1em2oRCVZhFFvbHRreQdTjfMy3TZQjV7RRsh6RN2,iv:IIUdiHdi9y5IuRhunCeEk6/2Yp7yyw21XyQzqsHUA0E=,tag:ML9KUv/5/RXB7WGc73Bz5A==,type:str]
+        crt: ENC[AES256_GCM,data:BrId47NWhogImSlhetV82Eh+B9RXqJf2kjEvkPq820sQy8KjYWMWTJOwmHBEgqjkX9okQyvmfkYgS1iyx5/r5r0KuYo6G8KqcKqDP5kiP6mLydPCqrvvYmtvlaxsLOCXX56KXGiBPUhFDrr7Ygp3+4zkX97A5bvgcvv3WIYq9ZpggapsMCU+nGlWkokkUbn1AAX7aiaDnDxMgl/sOvXyx80oN4qDn/QxuFSElbncJ4RJge50Am34ugYVteCLW/vyo9HNy7iYxPHqCbSQYXKir89hy++4L/kyMJC5sQYi8nynUsp1pKXhKChcAFNmmvo0XLnM45WXh1y9duMA/SQj3ve3cUXgZRHXHvTd4iGb/3G3udt6peBaAv4wtYl9WOM6+DRVpbiektzGjSn9c1H4WdzHUe0dieWPZLzfeZv21fceJ7rtrUwaw3xG3dCfCLqmcz9IZYhz5mYUsF3ppujjI7yHp9jeTg+xoSQs/iQbe1oIoR7E8DuxMTxmu3lU/K5pwOprvWwvzgOsjNh5E/z5KHlBOIGBPcJalk4L7XVbc+cxHYI8mP5g5NecJsrVgDLP5NttZYq9Mp6b1j5L6JeZIHJs4s+vlqBYseuGftTcmqu9mE/T9kRb/1e/BwvQ5RM/1/CXeT9ZG+nBXkNGVZSuC/awdklxwNfvdKjwUlubdx66UjvVOQeCZbhyhUCHJEEnfk0PCETArmN8MYbuPK+k012051cxAcg8q64ZkACKjXHSz/k+6KJ5Ak25a/EZCJrjMEMn3q/Xx8wBUY6gsTvW0cWW1Xkvq1qTHxiV9Ih9pYZW+l+8QQV/KE3f95lTTNSB/SCP5H3Ii/wHLL8aa9WxCkM+JlovBpTBscBuUPR4MqP+bbvA,iv:A+OLh/QcqBVFMmTMg+GN1rmrcMRdsyjYsxZorhgX7Kk=,tag:4T55suz9ulWkwyx3IIJ9VA==,type:str]
+        key: ""
     # Extra certificate subject alternative names for the machine's certificate.
     certSANs: []
     #   # Uncomment this to enable SANs.
@@ -21,7 +21,7 @@ machine:
     #   - 192.168.0.10
     # Used to provide additional options to the kubelet.
     kubelet:
-        #image: ghcr.io/siderolabs/kubelet:v1.30.1 # The `image` field is an optional reference to an alternative kubelet image.
+        # image: ghcr.io/siderolabs/kubelet:v1.30.1 # The `image` field is an optional reference to an alternative kubelet image.
         # Enable container runtime default Seccomp profile.
         defaultRuntimeSeccompProfileEnabled: true
         # The `nodeIP` field is used to configure `--node-ip` flag for the kubelet.
@@ -47,7 +47,7 @@ machine:
         #       options:
         #         - bind
         #         - rshared
-        #         - rw        extraMounts:
+        #         - rw
         extraMounts:
             - destination: /var/lib/longhorn
               type: bind
@@ -56,23 +56,23 @@ machine:
                 - bind
                 - rshared
                 - rw
-        # # The `extraConfig` field is used to provide kubelet configuration overrides.
-        # extraConfig:
-        #     serverTLSBootstrap: true
-        # # The `KubeletCredentialProviderConfig` field is used to provide kubelet credential configuration.
-        # credentialProviderConfig:
-        #     apiVersion: kubelet.config.k8s.io/v1
-        #     kind: CredentialProviderConfig
-        #     providers:
-        #         - apiVersion: credentialprovider.kubelet.k8s.io/v1
-        #           defaultCacheDuration: 12h
-        #           matchImages:
-        #             - '*.dkr.ecr.*.amazonaws.com'
-        #             - '*.dkr.ecr.*.amazonaws.com.cn'
-        #             - '*.dkr.ecr-fips.*.amazonaws.com'
-        #             - '*.dkr.ecr.us-iso-east-1.c2s.ic.gov'
-        #             - '*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov'
-        #           name: ecr-credential-provider
+                # # The `extraConfig` field is used to provide kubelet configuration overrides.
+                # extraConfig:
+                #     serverTLSBootstrap: true
+                # # The `KubeletCredentialProviderConfig` field is used to provide kubelet credential configuration.
+                # credentialProviderConfig:
+                #     apiVersion: kubelet.config.k8s.io/v1
+                #     kind: CredentialProviderConfig
+                #     providers:
+                #         - apiVersion: credentialprovider.kubelet.k8s.io/v1
+                #           defaultCacheDuration: 12h
+                #           matchImages:
+                #             - '*.dkr.ecr.*.amazonaws.com'
+                #             - '*.dkr.ecr.*.amazonaws.com.cn'
+                #             - '*.dkr.ecr-fips.*.amazonaws.com'
+                #             - '*.dkr.ecr.us-iso-east-1.c2s.ic.gov'
+                #             - '*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov'
+                #           name: ecr-credential-provider
     # Provides machine specific network configuration options.
     network: {}
     # # `interfaces` is used to define the network interface configuration.
@@ -174,7 +174,10 @@ machine:
         # The disk used for installations.
         disk: /dev/nvme0n1
         # Allows for supplying the image used to perform the installation.
-        image: ghcr.io/siderolabs/installer:v1.7.6
+        # Talos image factory generated link with following extensions:
+        # - iscsi-tools
+        # - util-linux-tools
+        image: factory.talos.dev/installer/613e1592b2da41ae5e265e8789429f22e121aab91cb4deb6bc3c0b6262961245:v1.7.7
         # Indicates if the installation disk should be wiped at installation time.
         wipe: false
         # # Look up disk using disk attributes like model, size, serial and others.
@@ -364,15 +367,13 @@ machine:
 # Provides cluster specific configuration options.
 cluster:
     # Globally unique identifier for this cluster (base64 encoded random 32 bytes).
-    id: ENC[AES256_GCM,data:Br9fyLY0/ZdCeTu2xcrSkzW+faJh5guqhsQ0g2OqxYlvKDP0kG6+3CQi5rM=,iv:BvGKAMhRr8eJe46bfcFF0T48lx1TC5tlkM6e4M3UWgg=,tag:i6fZ+zGaOl6PX/wupgC64A==,type:str]
+    id: ENC[AES256_GCM,data:keaJggCE83BJUtf7T2F47yfNEqIxMXT+0NgD9qNcxPL3GamMlk+Ds0BazpU=,iv:p1GlQyBYDlWokfQbGZ2VNRn45xE2EA1DpY2FjWCglOI=,tag:274/mF0Si9Rr9KwoWQtbLw==,type:str]
     # Shared secret of cluster (base64 encoded random 32 bytes).
-    secret: ENC[AES256_GCM,data:9jyT2HuasbB6n5exJ880W+CUbiWrSgH+qvtT2CBeoi0QUdbXefLSIbccPF0=,iv:jiNDeJKGS3TTgNSyJ5OxO6+91inHnQdnVsj2pyuM6ak=,tag:4PYe31TXmXmdVB90BQlzfg==,type:str]
+    secret: ENC[AES256_GCM,data:fCuAyS85XkrgO1TGMCeKefgab/yYAwM5RO1/pn2leDaGl1JbKQyJtEyaRiM=,iv:+tfvkBp2iWOgEUCqwUySHWFXKtFFkdcpRMfrThE2TdM=,tag:6saN2T2tgsIX8/CtgPJGmg==,type:str]
     # Provides control plane specific configuration options.
     controlPlane:
         # Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.
         endpoint: https://btrkube.menia.cc:6443
-    # Configures the cluster's name.
-    clusterName: btrkube
     # Provides cluster specific network configuration options.
     network:
         # The CNI used.
@@ -388,69 +389,17 @@ cluster:
         serviceSubnets:
             - 10.96.0.0/12
     # The [bootstrap token](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/) used to join the cluster.
-    token: ENC[AES256_GCM,data:HIKLsqC8+4XaXXQf/ndRosxzynbwVqg=,iv:aG5q7xf1R0eDGKJdD3srXmEHcPkuDJPJ8lcKTre6j5Q=,tag:uPyvP8vwk/I16X27YZSK7w==,type:str]
-    # A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
-    secretboxEncryptionSecret: ENC[AES256_GCM,data:vaJmjfeY2GJxh58PTHS5a5Q/0eFheAo4LZeAC2JSu+KT+emMtAuu7dNEXYg=,iv:SA6wlwTrhj+ynikSchtOycwzDXdHlfJm0OyWKCuVxgo=,tag:ElHrqczAG51XIEiKWzJ8kA==,type:str]
+    token: ENC[AES256_GCM,data:LIiOz/BBgJcBEmqoUy1BpPE9M2TDh+0=,iv:7CXqlkQrlYC+3oZLsH248MQWkF6mVa7fNgoDPycrNCQ=,tag:/Yx+uO5l5HPg84wzCjZ2Iw==,type:str]
     # The base64 encoded root certificate authority used by Kubernetes.
     ca:
-        crt: ENC[AES256_GCM,data:HeJV6N/FjNKZHP53azboYTCVdS1hpSP248WA2JLwyMcZ4UMu8bzPQm6l3QCmH3RBNff1Y4QqI41nGK17p4O9MTpF/BAYJprE+RDs5dbX7KQdY2zSd/K8g+JfA4u5WoS45Imvcv7t2Aiu7ACygm9nQIiNydr2RgduDkeEzRUln1f0w6w+vVvtmllTu3eObcPVTLXSA59nVsVZ+qyro+HpYt7kATWZRzYxh/HUQsBKxggDa4U9RCeoKT6NflWNmLH98EfOyiRjoLbE9FAgPWn9R0BROUVY9ob2rbHjxHwn9zUKRdSslKJgUgMPBgnIAs37KgaVdWTda2AWSbQJJt/QjU0oM7Fgn/Ur6AdviNeeQcACFot8SBJokRm0fvYBVlPxVBgIFoHOs9jTdzgmXUgGnrrhjNC8Kr1vHNW1aaK3mG+d/3qKDd32patY5ieLlOMAx2vOvfgdcjcqvHq8Ets2ebCgtPSZ4njvV8k0sFUFKAZ6IhPHchjfBhANnzjQ0smXaWfPMV5Kuzug7Mo6fUV1g+gSJmYV6LtoDDS29VcUhPN8cbVGgOoVFWF6rgfeS9S4Fty6Y4MOMUM6bb6Fp3AkHiZK2LzCLTfQMITGkFqAoANmwa8Qf9M0zB9pZB9NQ8UBg3kpqg1Py1j+NJfOllyOgb4Ft0Fy6+f5VxDdrQuzdDDiS96KxQ+XGIvcuVw8YjDgPAymOLAW08+RaxSz0UCigoIKok2xaQD8Ocdr7HPvv4dobjpGCW8JbX/GAacg4OZepp31B7QCZORXWu8R+2BQiFeXDCLsvnFyRVYD50+0HN417tekzZU3mcywrF8N7YzGyHlp05zmXwVnJNJPahaQknUzzen3dvtpLlT+0l0uqmvjcElZcEym56zGJ6fsR2L2LY1T3I0w0x+IF2ouqDzYg4SUtWH4MgyuaHydNqVxuRCWusrpfgyxMp/NX3CyfG7HA9QUQwWOLNkznoUABU7qtdgg73ZhBUh0mauxy95e1wC2TpzKuaYdPfXVtvLKsHva1zKG+S/3K3j5L+hKJyhkgKRtGtrUoynEFwSh0Q==,iv:V+IwncZs9AGshiLTmOEPRPwZPOlAsNWieAPWh4TmQsQ=,tag:zsvekJE4F04R+MDouwvvMA==,type:str]
-        key: ENC[AES256_GCM,data:ZXUzqx31ZoNeKqVfiHMqBPivi57qOC97K/V4c1kgiAZ8CTC6ApGNqtxww8ios9C1Qs/6AX9YOxivp3RRjIHcHKl1iCfdkeIYn0VwFiCoZLSw+zNltTsXc0rh7kswtx5X3Oydnztk72sjeLNjoNQQ8EQj7ckS9N5yFmck1GS1rxGWL8Wj6y6xlbdHOL4wFiH4KfncCpv5Q2KKsfZk7YN+yGJq6QHb1G4UE77TUMiQSKWwPncKg+4NF1V62IEsagkSSSuUKMXN7jAbfvAvh6/LLl0Bl6I2F++Wy9xnWUyYtKDi5Ti7g+uklPmkXaHfI60kUodPmDkJ2jsmNE6QzALStcMogS0MtkhGOm52fzxcWKzyPwvOYUyaD6fMPkE4Rr30QjChs/x9Mdsi9eXst10gOw==,iv:+upTux7NPDdsoneSy97nQb56OttZF7WRpu5hNgl8F6Q=,tag:TqkrgELhm8IyPsWhKnpKTA==,type:str]
-    # The base64 encoded aggregator certificate authority used by Kubernetes for front-proxy certificate generation.
-    aggregatorCA:
-        crt: ENC[AES256_GCM,data:tciEuw+6zNdyxqjwlzPqN/jnRvt2zpSWZdQTlsBHYX0JW4+u7m7HLvgSLpZcFqrT144LwT1LGsDnkzIs1tR9Ezl1WnmP2EmWZdrnWgcNyi3yEOlrYK1nqJvACAPrr1K3Wau026SxsN+G7nO3cPrax7XMjTcQ5jqEzlOI7rKpEvvYWk5YM1Cg4NIQzYzInU8YjK89CHPYiOag6IOaQ9R3g2NZHSZAe/egPJvV+lLGlHkLGC89jkV79F9AFrJR3RF8h+iEfr0cNRLRRl2hquEhx+KA1tCtXdQ+I5sHcRSQd9wwxPIouc6NzI2OMPDFziDku79zuD96cu3GWmQNe2sFVIxK5pSheMP4cFJKaE0VxNrmQGNJO4FQqM243gZoPEZME4SNGZ9z5Uand6HHVnU78gU8We6yl96zuI0EC4IHianXG+22LT/GdpQ5iEPrgPpoF2r9XaA4ZiJSdo7GM1lKTKPDrMYSkFFhhb+0Y70Q9coZmGr+5nqVUkha4/FZcGqD7snBASWQwAsP940HGtQqPmRjMImYvTV6ZdjkXVrccb1Vk9pDy5HjniuxDhnFXNj2hm2th+0PlIn2CKaJIOquYMk6bj+ZR2Fy7ha734oSjB8FuvuCRaeGjBZ7PB0oX8wLjXlow9tNl3UFGKzaWXiKafkVS9lDAXQWAjvXSiRnLvOO91Evh0Gr0XCKU4WMEIeL+shsMzZSfBIyMm4SaxF+FWGXlmTcoBl+/X4hnoE2j8t/xK0yg1mw3Dc1N3Lk1XXsBfD2qTz68/n0tIxp9erS+bmyR3cLyXQxCmhLaFe5bw4NbI3doMhEDS9J8FUkzsEnYtdJLLvJWcUjOw9HMoNEBdLmrM7g2Wwty86FTYX4DLPHgwbsAoKGqpuQ6USwFvZZNJMidW+SE1cFbaU52H4ZnF7j0d3xfBr2LCYXq72QCCmirIL1YhxJZC+SX0M+ZiWN,iv:NlF6UaVsPKxzgaE4axBQbW4SFLxDssZBM1otkrU8Dvw=,tag:WXx2cshMl8Ojb0p5fKv6lQ==,type:str]
-        key: ENC[AES256_GCM,data:3xUdeAUutF+kCBgyUIhQ2Zz3WT4P29UFS57k++5HZs5rPadRQckfiy/m7e3Fu8wGBSxmXCdDK12AnsIWy/a9oKxN/ZiRXryCWT48MmxsyU59ho2p4U+62Rx1CMSYbfVFkTODmxZg6Wr4DRJYRsRYqyk4y0eqgIrsO5IpiOdk6PAODiWl8PyPXQjcT4gErhARNe9TyV1FjV9fqxy5dG6vwoztLEAuyI4tHYeQEwhzLqhVEbNA9jFTRpC59wUhQ8DlUnAbyqjnSaPx7qqh1n4P4rkaCTE3JTZhrHJwlXINVy+TZB49KM0pLY+A4wpn5Ug2xz1rX1Zu/NdNCeOZlezw0DmSe/TBpKAu4sFi9VHAcrH6wKV7o85FBFA2hRHMVrubCFINghbyXCGMKdzs2rME1g==,iv:KvP8I0viWVCb80r1GBRXlMD6xYmV/+4fm9G8KJrWD7E=,tag:ymaEqUv2SE6jj8kLsKtzGQ==,type:str]
-    # The base64 encoded private key for service account token generation.
-    serviceAccount:
-        key: ENC[AES256_GCM,data:mlNuITeRWzHHiqAMAcTztP9QKjakhy8Hw9/9n3+6R60eoCpnjHoTOhwTki0K7dFe1hzIPnyc95jfTgc1j2YizZP4wciXSLxSjMF3PxrY2khv3LAZUekFvkLdfYLI44y0nsxgo7aYXvZm3hqPpvpbCrqJ63PdgOpEDMd/TD4l68gbAaCwCf+T50Cu0pCDBeSIxdh6l3EX7Xek2ahX9NGgSHpx2K9jnquCRqe1JfaKUQ3yyrYINco2+svtCZGzkSgzQAEjSqjUDSiKlZwKuK+3PK8Fwj9cDLvbGDg0gw0JTZbKlfXJobb/BUC3oGAcUSxideDMlBV34vY/Ifkg94re7tXsfLGm6XH7lO4pt0Di/VwhHe6xjPtC51o8Nnb6cFcpljrJUWmmWX5ZSKBHaTKGhA==,iv:IyYJL1skQUWwKhmlbnpleddXSqqZpfeZ2V3ePsV8WIA=,tag:MIm8sR6OcCAJWblfBcXR9A==,type:str]
-    # API server specific configuration options.
-    apiServer:
-        # The container image used in the API server manifest.
-        image: registry.k8s.io/kube-apiserver:v1.30.1
-        # Extra certificate subject alternative names for the API server's certificate.
-        certSANs:
-            - btrkube.menia.cc
-        # Disable PodSecurityPolicy in the API server and default manifests.
-        disablePodSecurityPolicy: true
-        # Configure the API server admission plugins.
-        admissionControl:
-            # Name is the name of the admission controller.
-            - name: PodSecurity
-              # Configuration is an embedded configuration object to be used as the plugin's
-              configuration:
-                apiVersion: pod-security.admission.config.k8s.io/v1alpha1
-                defaults:
-                    audit: restricted
-                    audit-version: latest
-                    enforce: baseline
-                    enforce-version: latest
-                    warn: restricted
-                    warn-version: latest
-                exemptions:
-                    namespaces:
-                        - kube-system
-                    runtimeClasses: []
-                    usernames: []
-                kind: PodSecurityConfiguration
-        # Configure the API server audit policy.
-        auditPolicy:
-            apiVersion: audit.k8s.io/v1
-            kind: Policy
-            rules:
-                - level: Metadata
-    # Controller manager server specific configuration options.
-    controllerManager:
-        # The container image used in the controller manager manifest.
-        image: registry.k8s.io/kube-controller-manager:v1.30.1
+        crt: ENC[AES256_GCM,data:C9jYc7C0fzLflIe6BEuZGm4a9eHCnF4ZYz/3Yx7iDyPDGN5EJLqJzi7bnMyloeCO4hKnCZ8K9Hq0AdNBgfkyeqP8qSxQShgFSMKsusQyZL0a85nPl9ik9K6ZpjrtOPtLPguTepuEskG5b8kCgFRfV5FQNco8bkQpb/mtsJY3cGA8CybwXXPCF/IFPNmU/9BHGh/H9khhIDfP2b/b6zLZ/5FuMv8xgdUrFognBiDYL+Bt5PAE7UmjCuNJZ8kWL+4Nz9wI4ZsHiEWYs3+bbOqyTRHR5loB7UextrLXx7gYeb3hR1JMCDXI10g0fLrZIb/PHRN5vLr+uji2dzSgoz5gHr5v5fDjh1PYofeplnvr2EOTUHc2wo68mJQDk9dZGQjf+guRYNFowzIArlumdRHLMt/HPStfQ1udNWDwvxi9ZLXXDmzqu6PCK6JE3CvRvagVApaWnLuBHL0Moa/gonp/CiDc3lZfErfRbtSBfL6PMnZqqLKtJMFPq2bB7g2JuQMiUrDWYuXyw+Wm62BGsUKd7XLV5Uv5njxngbi2SL6qqVYRHeES26W96M4mAFMzcg+Yr4sYtimkdfLkUc6kbmF/YJuZHaMi8HkcYtDANLuRIYnpVJT0uVrS/noGcCodvHvdJ31RjGwDeQxXDf2VKKfONf7uqcfeDGZEUj3CgLGYQBiVLnVHwEBkhuxLaUokKs5Hmj63PMI0v6+gtdYb5wXcRa3I7sivQ45AsSBiOI4xgbkmeJ3g6h6QIxF93hkeeOkh0E5i0Qd5Kt2nQB7OcH2mgjofU/1K6iGic2dQDGhpSH+vYKNWl/VkGpLN9C3fL7anq23oZWR+XzLGqLn6Ba1EcEgl3G1Li/gymbcpuMNOyPIVGV4UqtjyXupw1xYLBf6M6CHG8xNhrgRsq1zC+OiyruKyUmDOkvNP7G1TpJNAFK0vVZKIWrLJXF0ByRFMEFtaP5tbR/VNgb0+bLl9WjteAYIx2XkuLxn36Clr3+S50Zy17biTj2bWg8nB9Y01v3ALAb9ltTNebovdMxucELRKqP+9rPU8q/DNXTsyXw==,iv:hd0XAxBCL6i6lM2+c9NL/Opv0xf2qn0cW7EBCBcy2zc=,tag:GdEz7OJpH5cABYhalLPelA==,type:str]
+        key: ""
     # Kube-proxy server-specific configuration options
     proxy:
         # Disable kube-proxy deployment on cluster bootstrap.
         disabled: true
-        # The container image used in the kube-proxy manifest.
-        image: registry.k8s.io/kube-proxy:v1.30.1
-    # Scheduler server specific configuration options.
-    scheduler:
-        # The container image used in the scheduler manifest.
-        image: registry.k8s.io/kube-scheduler:v1.30.1
+        # # The container image used in the kube-proxy manifest.
+        # image: registry.k8s.io/kube-proxy:v1.30.1
     # Configures cluster member discovery.
     discovery:
         # Enable the cluster membership discovery feature.
@@ -465,32 +414,82 @@ cluster:
             service: {}
             # # External service endpoint.
             # endpoint: https://discovery.talos.dev/
-    # Etcd specific configuration options.
-    etcd:
-        # The `ca` is the root certificate authority of the PKI.
-        ca:
-            crt: ENC[AES256_GCM,data:/QavM2EokJmkrqS1a/KjuvFZxDVRNePqCgEqLhKI6l9zuYm3QHipwaxQl1fiZ4Hd3Fpd0df9Dk9cBVHrJHAlaCwqUIXV6oz599mvtkxUWztjSwVe2NacRtzVre6zKGEF7taZLAG0VjXeOrbSiGGpkOdlAId9K0VwbDp/AQrhpAExG1bArtM7miJMea0ROKSh+bk6C+hAlNSgNBsDkImWvffMOS0et9+WiXs3ul0cKd+A3V4HreRbZE+I6ZUe8XSiSJ4IRf00CIVA111ce43bW9TMc1EdfThvakRljcjRh3g9MLt5o9UhveF3no8w/a9rEccVQy5zoAHkOFsVKHs0cFMMaZbW6Xm2pFch/W5HKlhIOD2yRiC53jIdryrTb0XWpD2j8Ozm+27VsfQxACyU+aUW64nJELtskyEb2w+0c/ACbuORLCp0ZmJP0yMHJB28kne6l39Pb9pCf18W0VX7jxuHLfsZAM2nm51a63eUwhCiAwsBQUsY2fxS3dKnnRDO0hVrAMhiB+m514/NKNFbbw34ABcAfPyOCOIdQHVchQEG+FcrnGvcj5jR2HV4IKgDkOks/CIe0qtN5CfpcSU7n6yNvyrQo/SudKxHO4TNJYTPK0jXal9HNS3NEyzIm3T0Dnj8k4iPhOMLxw5jR7K9/tEQixLPzq7xgM9isms3QF9pI4n398szoSk1+Q/MsEESJ8qh2wy/76XgEBxbVeT8To8yOHe3GFQjM+FJbVZM0gWVXgCjL2LIHh/XdL+59BK7A/GIFOv/HYAqs33eto2OADG7yXJE8joPwIpP2axJL0xvfWLVcZvRfwb1VSTu5PngCAnXL0NlL3LbtdMTcMUMIbZNiKCjYcEXgC3TBgGzsjXRdcPBE0w/x3Yi9SvA6TVfmtv3Je0CQpvfiOqeA0cqjn07uU6PsE1zCF9Z79XtSYAeTn6BZdiBCJdHZhDHxNWP9J2p1gsMRoX2zuFU0mpLzg/P+9llRkZx0ariK9ZjfBJ5ClFsVedxW2KoEwOi/0tF1Fcjrg==,iv:bEAmKFhiioOtfU9w5UyGCEfVsTsLCOXI7XRoqE4dEHk=,tag:hz8cI+M/8nzwLBVW4z31Ug==,type:str]
-            key: ENC[AES256_GCM,data:yxmEBHQIkOisAnimswL7DlbERBEyM+AJkv6wQt65q8NHrbR2RvE1L8EnB77QDG9aDIVG1kTuxYScyvUIVSAVbsrNNJ/QVftKFEv8O8yhnX0qsm8Lpj8KqgvKQSg/5NXmIaYlLG6CG3R5rdKU4GDq1s1dN67ufldBesUig66jnIU3qWedeQJevigfRnC1kjnbwtW8xkv8LEAZRu13qAkxTmZnXnXGP8qRYXsAnfZLtfIkHQ1vFlwVpNWPxMJkEKZtFx/ECOWrDtUDrFvHPR+OcJF8AcLxLmi2ALkZxREmUs0xV970tBDz+Lx5qk6F6pzRrcsE3laXqUKpAjf5xrwiWE2CZZuH/opPUEemjr8gj/kwvriSeW+ntobZbGt6GbzKxJnZTHYDkpd7ND1x2Q2Ctg==,iv:Hv2TlpnfMv0XeLLHjpHQTrO1xwrd4t+UkBgVL62l6fQ=,tag:sQNg3GqZKuRXFOSjlk/lCg==,type:str]
-            #ENC[AES256_GCM,data:9+raARNfPUjT+J3pFtxwAtlVjTSRmpyPOjNW6DuFRbbO/O1Nzh3c6cMEzZPdXjncWkDOKK06Yw==,iv:rNENvLipuK1jkuEwWfGEJdTA/V8j3mL7s+w39YbWRK8=,tag:zAaJHEhQUqymgNaubCjNpw==,type:comment]
-            #ENC[AES256_GCM,data:Cx+imC20RLBYQcO5lKfQD76wzAEr+xxG48suAVr+9D7NiH9pOfDSRXkclSvXo3RGiiM=,iv:ozikFBgv206UKOWd3E30R+UhAivJLLHbeLL3BYy89Dk=,tag:PGr6PgBkN4u5NvoqLOK0AA==,type:comment]
-            #ENC[AES256_GCM,data:mY+ZIHMMJQQNhPcLJ2MaDHdXXXh3bsyDX1U2xuIDTyWiTGb8TavV2wHnT4KB/qTBDIncHL5E571zlYvWrPl0KnAyZdJPWP1jaYuSjD0dwWclbsjGbc7wIAU=,iv:GpHDpl18UQ8F71UgEm0csV0tAAD9Ddpk98ttS0bpcPw=,tag:ORoZ3hXxIaRtzFA+C3Yy3Q==,type:comment]
-            #ENC[AES256_GCM,data:WMTTTl/mAhqaoqOKhSXVMjIXDQ==,iv:P+izwqG+cEr39/KvjVY8KiEAI8S4E2y35FvroYrLD8w=,tag:LMmsFCupemcBBjWGkvHncQ==,type:comment]
-            #ENC[AES256_GCM,data:5A5nt4/Fc7e5eBEIivjBvhI=,iv:o84TeHaD7U7J6yRDwthWbQ8bW1XRcdVkQk/++Ur4oKE=,tag:FRd4VSlFv+jRXYQ2zfXzPw==,type:comment]
-    # A list of urls that point to additional manifests.
-    extraManifests: []
-    #   - https://www.example.com/manifest1.yaml
-    #   - https://www.example.com/manifest2.yaml
-    # A list of inline Kubernetes manifests.
-    inlineManifests: []
-    #   - name: namespace-ci # Name of the manifest.
-    #     contents: |- # Manifest contents as a string.
-    #       apiVersion: v1
-    #       kind: Namespace
-    #       metadata:
-    #       	name: ci
 # # A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
 # # Decryption secret example (do not use in production!).
 # aescbcEncryptionSecret: z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=
+# # A key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+# # Decryption secret example (do not use in production!).
+# secretboxEncryptionSecret: z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=
+# # The base64 encoded aggregator certificate authority used by Kubernetes for front-proxy certificate generation.
+# # AggregatorCA example.
+# aggregatorCA:
+#     crt: LS0tIEVYQU1QTEUgQ0VSVElGSUNBVEUgLS0t
+#     key: LS0tIEVYQU1QTEUgS0VZIC0tLQ==
+# # The base64 encoded private key for service account token generation.
+# # AggregatorCA example.
+# serviceAccount:
+#     key: LS0tIEVYQU1QTEUgS0VZIC0tLQ==
+# # API server specific configuration options.
+# apiServer:
+#     image: registry.k8s.io/kube-apiserver:v1.30.1 # The container image used in the API server manifest.
+#     # Extra arguments to supply to the API server.
+#     extraArgs:
+#         feature-gates: ServerSideApply=true
+#         http2-max-streams-per-connection: "32"
+#     # Extra certificate subject alternative names for the API server's certificate.
+#     certSANs:
+#         - 1.2.3.4
+#         - 4.5.6.7
+#     # Configure the API server admission plugins.
+#     admissionControl:
+#         - name: PodSecurity # Name is the name of the admission controller.
+#           # Configuration is an embedded configuration object to be used as the plugin's
+#           configuration:
+#             apiVersion: pod-security.admission.config.k8s.io/v1alpha1
+#             defaults:
+#                 audit: restricted
+#                 audit-version: latest
+#                 enforce: baseline
+#                 enforce-version: latest
+#                 warn: restricted
+#                 warn-version: latest
+#             exemptions:
+#                 namespaces:
+#                     - kube-system
+#                 runtimeClasses: []
+#                 usernames: []
+#             kind: PodSecurityConfiguration
+#     # Configure the API server audit policy.
+#     auditPolicy:
+#         apiVersion: audit.k8s.io/v1
+#         kind: Policy
+#         rules:
+#             - level: Metadata
+# # Controller manager server specific configuration options.
+# controllerManager:
+#     image: registry.k8s.io/kube-controller-manager:v1.30.1 # The container image used in the controller manager manifest.
+#     # Extra arguments to supply to the controller manager.
+#     extraArgs:
+#         feature-gates: ServerSideApply=true
+# # Scheduler server specific configuration options.
+# scheduler:
+#     image: registry.k8s.io/kube-scheduler:v1.30.0 # The container image used in the scheduler manifest.
+#     # Extra arguments to supply to the scheduler.
+#     extraArgs:
+#         feature-gates: AllBeta=true
+# # Etcd specific configuration options.
+# etcd:
+#     image: gcr.io/etcd-development/etcd:v3.5.11-arm64 # The container image used to create the etcd service.
+#     # The `ca` is the root certificate authority of the PKI.
+#     ca:
+#         crt: LS0tIEVYQU1QTEUgQ0VSVElGSUNBVEUgLS0t
+#         key: LS0tIEVYQU1QTEUgS0VZIC0tLQ==
+#     # Extra arguments to supply to etcd.
+#     extraArgs:
+#         election-timeout: "5000"
+#     # The `advertisedSubnets` field configures the networks to pick etcd advertised IP from.
+#     advertisedSubnets:
+#         - 10.0.0.0/8
 # # Core DNS specific configuration options.
 # coreDNS:
 #     image: registry.k8s.io/coredns/coredns:v1.11.1 # The `image` field is an override to the default coredns image.
@@ -501,10 +500,22 @@ cluster:
 #     manifests:
 #         - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/rbac.yaml
 #         - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/aws-cloud-controller-manager-daemonset.yaml
+# # A list of urls that point to additional manifests.
+# extraManifests:
+#     - https://www.example.com/manifest1.yaml
+#     - https://www.example.com/manifest2.yaml
 # # A map of key value pairs that will be added while fetching the extraManifests.
 # extraManifestHeaders:
 #     Token: "1234567"
 #     X-ExtraInfo: info
+# # A list of inline Kubernetes manifests.
+# inlineManifests:
+#     - name: namespace-ci # Name of the manifest.
+#       contents: |- # Manifest contents as a string.
+#         apiVersion: v1
+#         kind: Namespace
+#         metadata:
+#         	name: ci
 # # Settings for admin kubeconfig generation.
 # adminKubeconfig:
 #     certLifetime: 1h0m0s # Admin kubeconfig certificate lifetime (default is 1 year).
@@ -519,14 +530,23 @@ sops:
         - recipient: age1ngkdczpldhxhx8qchl0v7c9eq06vnc5yea3mhsuy0n20hvyescpqv3w2xy
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkQmE3bmRFSHpTaWR0SjhM
-            YmR3QjJ6M3V6cW9Fbk5qQnJ3cWxGc3hwT1RrCmtiQlVtZ01TTXVEV1dmdUFIcW5E
-            Ukk0eDhBUERTenBHb2E0T1VtU0lNZTgKLS0tIHlyQUtkb1pROCtSVVJkOHdySTNh
-            c05HZ04rR28reXdETEt5dm1CYkZqZ3MKlZJbJdDeMfzRcFNX8NlBb4OiBbmWlR6w
-            2v2ijuOFwRKxvAUR6gsillIGXGzrAze/8d76B6Tb/Pu8Qa3jNiTqDw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByeWlzN0lsNktzQzRCUjE3
+            NElaQTlpWjBlQmZ2T3dNWXR6YkNuWFJEYkQ0Cm0wL1JHenNjbUtxTkVwV0dWbkV2
+            TnA0bUgvdTlxR0dRSFdvSjREVGN0ZUUKLS0tIHlnYXBEN3pSaEdZd09uNFQ5NVRR
+            c0VHNXBYNDN6dmVZQ0lUTUc4QXJwVXcKnoocZohCyycxEZaXMBxLZGehTPxyObVL
+            IsrXc0vjDVrrD+Osdj54Dx94Z0PKpAtiEDLehnQNpw2Ilu4EnBFBmQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-05-23T02:38:43Z"
-    mac: ENC[AES256_GCM,data:YuFpafUTF6DQEWbHeU2C6KxGgtSM4VFCDGHYloIgSEmeJ0gfh+/zTSpj92Bt95pi+TMBZQ3JILwjR0Ei1DpdvVxyihDMjk5SMvZXvNd1k+Q0EqeqeZCJHQLl4Hr5aUOZNM7Rk4z4WZt0M4R35C9/45Jou0iMTyJCQbjPIHms5pA=,iv:Ke6po1uhZQLi2hCOR+GdIFncoandqd88flSfoTGlI0o=,tag:muefeSMkjtJq8VmgmSvWNA==,type:str]
+        - recipient: age1xzxw8fsvdz53aa3r8z6t4zns2cqadjm4ep88w5jf4zw3yhcflvesxgkxlc
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWUTNadzlHdW4xdHhRbTlE
+            QVdna1grK3ZnbmdlSkVYc0pDVmx0TlRFbmdnCm5MdzZjMFRHTHNYY2VFUzBTeU1B
+            bXAzRnMrUW5rVURBWWhHMllWbkpiVWMKLS0tIDVMc2hwa1pEWDM4cmVub2gwb3Q4
+            L0x5cDRraGtETkttSjFSYklkOHdDNE0KydwiewcYZAVjcbEzwnwV2wX/7Qp9JPp8
+            wxnME1LeP3u4uXmLzSOzLr7PIesBjT4kxQjY7msVysV7pfCq9V5pZg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-10-14T15:04:09Z"
+    mac: ENC[AES256_GCM,data:qA3dPF4nV0lFox55IQBZaT7A//rC9ZI+fUeK0KRtlAMYYRu4BuMl8gqyJnPYsHbOy24G/JFx8P9RoT1UEHof+a6xJKoRSHwMcMszY+GU9nV+EBloPGeM94AxBAgs0nFgdfubSbR961TjMgrF1+Kq1WU4u2w0fGSJm07F7sQNLvE=,iv:cBhcny/9NDZMUuS9c1vqttKEOdOyUEcDN7TRgYi7Xk8=,tag:zuh8GI0gMl8OgDFejUutKw==,type:str]
     pgp: []
-    encrypted_regex: ^(data|stringData|ca|crt|key|id|secret|token|aggregatorCA|serviceAccount|bootstraptoken|secretboxencryptionsecret|secretboxEncryptionSecret)$
-    version: 3.8.1
+    encrypted_regex: ^(data|stringData|ca|crt|key|id|secret|token|aggregatorCA|serviceAccount|bootstraptoken|secretboxencryptionsecret|secretboxEncryptionSecret|clientSecret|clientId)$
+    version: 3.9.1


### PR DESCRIPTION
My controlplane and worker configuration files were based on base Talos ISO with no extension, which required patch action after installation to support Longhorn required extensions. This update is fixing this by using an image from Talos image factory that embeds:

- Talos 1.7.7
- Kernel extensions:
  - util-linux-tools
  - iscsi-tools