### PR TITLE
Fix Cilium connectivity tests

### DIFF
--- a/docs/src/Core components/cilium.md
+++ b/docs/src/Core components/cilium.md
@@ -6,6 +6,8 @@
 
 ## Installation
 
+https://docs.cilium.io/en/stable/installation/k8s-install-helm/
+
 Following is related to my first experience with Cilium, but since I've made a Kustomization to handle and deploy Cilium, I'll keep it here for future reference.
 
 ```bash

--- a/docs/src/Maintenance/troubleshooting.md
+++ b/docs/src/Maintenance/troubleshooting.md
@@ -1,0 +1,12 @@
+# Troubleshooting
+
+## Web returning 404
+
+- ensure Cilium is running
+- if you have uninstalled Cilium and then reinstalled it, it removed all http routes you had configured
+
+## Network issues
+
+- check Cilium pods are healthy: `kubectl get pods -n kube-system | grep cilium`
+- use `cilium connectivity test` to check reachability between nodes
+  - this requires privileged namespace, deploy the one in `infra/cilium/namespace.yaml`

--- a/infra/cilium/namespace.yaml
+++ b/infra/cilium/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cilium-test-1
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/infra/cilium/values.yaml
+++ b/infra/cilium/values.yaml
@@ -43,6 +43,7 @@ securityContext:
     - FOWNER
     - SETGID
     - SETUID
+    # - SYS_MODULE # unsupported in Talos https://docs.cilium.io/en/stable/installation/k8s-install-helm/
     cleanCiliumState:
     - NET_ADMIN
     - SYS_ADMIN


### PR DESCRIPTION
Cilium connectivity tests and perf commands were not working properly due to missing privileges. Haven't found any way to tell it to create namespace with required privileges so I decided to add a file in it's folder instead that we can call prior to run any test. When test achieve, Cilium automatically deletes namespace used to test.

This is a quick patch for now, this will need definitively deeper study / knowledge to have something more seamless.