### PR TITLE
feat(homebridge): add new app homebridge

### DIFF
--- a/apps/homebridge/homebridge.yaml
+++ b/apps/homebridge/homebridge.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homebridge
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homebridge-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: homebridge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: homebridge
+  template:
+    metadata:
+      labels:
+        app: homebridge
+    spec:
+      containers:
+      - name: homebridge
+        image: homebridge/homebridge:latest
+        env:
+        - name: TZ
+          value: 'America/Montreal'
+        ports:
+        - containerPort: 8581
+        volumeMounts:
+        - name: homebridge-data
+          mountPath: /homebridge
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: "0.5"
+            memory: 512Mi
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8581
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+      hostNetwork: true
+      volumes:
+      - name: homebridge-data
+        persistentVolumeClaim:
+          claimName: homebridge-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: homebridge
+spec:
+  selector:
+    app: homebridge
+  ports:
+    - protocol: TCP
+      port: 8581
+      targetPort: 8581

--- a/apps/homebridge/httproute.yaml
+++ b/apps/homebridge/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: homebridge-https
+spec:
+  hostnames:
+  - homebridge.menia.cc
+  parentRefs:
+  - name: shared-gateway
+    namespace: default
+    sectionName: shared-https
+  rules:
+  - backendRefs:
+    - name: homebridge
+      port: 8581

--- a/apps/homebridge/kustomization.yaml
+++ b/apps/homebridge/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: homebridge
+
+resources:
+- homebridge.yaml
+- httproute.yaml


### PR DESCRIPTION
Add support for new app named homebridge. Homebridge is a way to make compatible Apple HomeKit what is not designed for.

It's a move from a Docker compose file to Kubernetes manifests:

- use StatefulSet
- use PVC
- add privileges to be able to run it on host network
- use hostNetwork: true

There is probably other ways to handle homebridge that are more secure. If you know anything that can help, please open an issue or provide a pull request. Thank you 🔥 !