### PR TITLE
Feature: add longhorn auto backup and snapshot

### DIFF
--- a/apps/homebridge/homebridge.yaml
+++ b/apps/homebridge/homebridge.yaml
@@ -11,6 +11,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: homebridge-pvc
+  labels:
+    recurring-job-group.longhorn.io/auto-backup: enabled
+    backup-frequency: low
 spec:
   accessModes:
     - ReadWriteOnce

--- a/apps/n8n/n8n.yaml
+++ b/apps/n8n/n8n.yaml
@@ -7,6 +7,11 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: n8n-pvc
+  labels:
+    recurring-job-group.longhorn.io/auto-backup: enabled
+    recurring-job-group.longhorn.io/auto-snapshot: enabled
+    backup-frequency: high
+    snapshot-frequency: high
 spec:
   accessModes:
     - ReadWriteOnce

--- a/apps/redbot/redbot.yaml
+++ b/apps/redbot/redbot.yaml
@@ -7,6 +7,11 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: redbot-pvc
+  labels:
+    recurring-job-group.longhorn.io/auto-backup: enabled
+    recurring-job-group.longhorn.io/auto-snapshot: enabled
+    backup-frequency: high
+    snapshot-frequency: high
 spec:
   accessModes:
     - ReadWriteOnce

--- a/apps/thelounge/thelounge.yaml
+++ b/apps/thelounge/thelounge.yaml
@@ -7,6 +7,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: thelounge-pvc
+  labels:
+    recurring-job-group.longhorn.io/auto-backup: enabled
+    backup-frequency: low
 spec:
   accessModes:
     - ReadWriteOnce

--- a/core/longhorn-system/auto-backup-high.yaml
+++ b/core/longhorn-system/auto-backup-high.yaml
@@ -1,0 +1,14 @@
+apiVersion: longhorn.io/v1beta1
+kind: RecurringJob
+metadata:
+  name: auto-backup-high
+  namespace: longhorn-system
+spec:
+  cron: "0 3 * * *" # every days 3am
+  task: "backup"
+  groups:
+  - auto-backup
+  retain: 60
+  concurrency: 2
+  labels:
+    backup-frequency: high

--- a/core/longhorn-system/auto-backup-low.yaml
+++ b/core/longhorn-system/auto-backup-low.yaml
@@ -1,0 +1,14 @@
+apiVersion: longhorn.io/v1beta1
+kind: RecurringJob
+metadata:
+  name: auto-backup-low
+  namespace: longhorn-system
+spec:
+  cron: "0 3 */7 * *" # every 7 days 3am
+  task: "backup"
+  groups:
+  - auto-backup
+  retain: 8
+  concurrency: 2
+  labels:
+    backup-frequency: low

--- a/core/longhorn-system/auto-snapshot-high.yaml
+++ b/core/longhorn-system/auto-snapshot-high.yaml
@@ -1,0 +1,14 @@
+apiVersion: longhorn.io/v1beta1
+kind: RecurringJob
+metadata:
+  name: auto-snapshot-high
+  namespace: longhorn-system
+spec:
+  cron: "0 2,14 * * *" # every 12 hours
+  task: "snapshot"
+  groups:
+  - auto-snapshot
+  retain: 60
+  concurrency: 2
+  labels:
+    snapshot-frequency: high

--- a/core/longhorn-system/auto-snapshot-low.yaml
+++ b/core/longhorn-system/auto-snapshot-low.yaml
@@ -1,0 +1,14 @@
+apiVersion: longhorn.io/v1beta1
+kind: RecurringJob
+metadata:
+  name: auto-snapshot-low
+  namespace: longhorn-system
+spec:
+  cron: "0 1 */2 * *" # every 2 days at 1am
+  task: "snapshot"
+  groups:
+  - auto-snapshot
+  retain: 15
+  concurrency: 2
+  labels:
+    snapshot-frequency: low

--- a/core/longhorn-system/kustomization.yaml
+++ b/core/longhorn-system/kustomization.yaml
@@ -5,6 +5,10 @@ namespace: longhorn-system
 resources:
   - https://raw.githubusercontent.com/longhorn/longhorn/v1.7.1/deploy/longhorn.yaml
   - httproute.yaml
+  - auto-backup-high.yaml
+  - auto-backup-low.yaml
+  - auto-snapshot-high.yaml
+  - auto-snapshot-low.yaml
 
 patches:
   - path: namespace.yaml


### PR DESCRIPTION
- add recurring job for backups and snapshots
- with low and high frequency for both
- and apply to apps that needs backups

Note: there is a feeling of repetitive labels, I've made the choice of "groups" to ensure it's shown in Longhorn GUI as I was not able to just find pvc labels.