### PR TITLE
feat(apps): example to add game necesse server from LGSM with playit tunnel

### DIFF
--- a/examples/apps/necesse/kustomization.yaml
+++ b/examples/apps/necesse/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: necesse
+
+resources:
+  - namespace.yaml
+  - necesse.yaml
+
+generators:
+  - secret-generator.yaml

--- a/examples/apps/necesse/namespace.yaml
+++ b/examples/apps/necesse/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: necesse
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest

--- a/examples/apps/necesse/necesse.yaml
+++ b/examples/apps/necesse/necesse.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: necesse
+  namespace: necesse
+spec:
+  serviceName: necesse
+  replicas: 1
+  selector:
+    matchLabels:
+      app: necesse
+  template:
+    metadata:
+      labels:
+        app: necesse
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
+        seccompProfile:
+          type: RuntimeDefault
+      resources:
+        limits:
+          cpu: "1"
+          memory: "2048Mi"
+        requests:
+          cpu: "0.5"
+          memory: "1024Mi"
+      containers:
+        - name: playit-sidecar
+          image: ghcr.io/playit-cloud/playit-agent:0.15.26
+          envFrom:
+            - secretRef:
+                name: playit-client
+          securityContext:
+            privileged: true
+            runAsUser: 0
+            seccompProfile:
+              type: RuntimeDefault
+        - name: necesse
+          image: gameservermanagers/gameserver:nec # https://github.com/GameServerManagers/LinuxGSM/blob/master/lgsm/data/serverlist.csv
+          securityContext: # LGSM Docker use gosu to switch to non privileged user when started
+            runAsUser: 0
+            privileged: true
+            runAsNonRoot: false
+            allowPrivilegeEscalation: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: SERVER_PORT
+              value: "14159"
+          ports:
+            - containerPort: 14159
+              protocol: UDP
+              name: game-udp
+          volumeMounts:
+            - name: necesse-data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: necesse-data
+        labels:
+          app.kubernetes.io/name: necesse
+          recurring-job-group.longhorn.io/auto-backup: enabled
+          recurring-job-group.longhorn.io/auto-snapshot: enabled
+          backup-frequency: low
+          snapshot-frequency: high
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: longhorn
+        resources:
+          requests:
+            storage: 10Gi
+        volumeMode: Filesystem
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: necesse
+spec:
+  ports:
+    - name: game-udp
+      port: 14159
+      protocol: UDP
+  selector:
+    app: necesse

--- a/examples/apps/necesse/secret-generator.yaml
+++ b/examples/apps/necesse/secret-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: tunnel-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - secret-playit.enc.yaml

--- a/examples/apps/necesse/secret-playit.enc.yaml
+++ b/examples/apps/necesse/secret-playit.enc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+data:
+    SECRET_KEY: ENC[AES256_GCM,data:SQO3w3FKFWL4vYn8NhxxwTfx/pNqGnU8YqOEXgM7z+2XULnBl9MYUQUbVXQRvTh8bFmq/w6QglB/+/ITzMVCSolIKYhJhQBQOoyHkiorJ9Re8Bz9z31SCg==,iv:RSuoGVuIx+EDb++6QWYlFttTQQQJEDtiaRYZwDMleu0=,tag:objm9+RHnjkWWFU7wg5gbQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: playit-client
+sops:
+    age:
+        - recipient: age1ngkdczpldhxhx8qchl0v7c9eq06vnc5yea3mhsuy0n20hvyescpqv3w2xy
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2U21QcGFUdy9mTzE0WWQz
+            dWgzaFBnZ3FaMkx2SE1SWVhjRW1JY09BT3dvCm5NNnA3QTZZL3lZSWRrV0VKeXhW
+            TXVPdVloVlBiVURDTUdaWVZiWG4yWUEKLS0tIGtFRjdXd095UjNWRlJ0dU9adysy
+            NlJ5TFZqUzhLdlBqR0NRSlpzb0tMR3cKHkQ/piVjYEDpdZRD9R6FhWgIC5dGFmXm
+            Pr70J1pAPCX/NdACXD7xFx3uaFVzp547RyrU8lyriLv9U3Nb7nq21w==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1xzxw8fsvdz53aa3r8z6t4zns2cqadjm4ep88w5jf4zw3yhcflvesxgkxlc
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVTUxxeW1vRFMxbnNuMGtt
+            eGR5NDl2MEtYTFVlUU1QcVg0SzlJeHF0VUhZCjBmTExhMUFudzRETVNVOTZ5eHlK
+            aFI5WnZOTlM2SnhVbU56aUpSU2FZYWcKLS0tIHJwcWU1ZHZnZEpnNVZCUjZBNUdk
+            T1VQa2NDQWV2QmNNYmptc0ZybHBYLzQKm0hG3QT5qDO0Iti+vwzeeY0FB+cQw5EV
+            iWn6zQde6+c1AjgYRQ3EFT+xAQRfO4HQaM488iz4VcAZecGCqhfYWw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-10-21T16:57:07Z"
+    mac: ENC[AES256_GCM,data:PxKkU8QWWdv+TOYYQd5hPsSK8Ju8lglJwoz2anrcbZXYsf20R4Mr3Ms+EU4Mw5Auz7XV9MVehCqqq94MYkKtsLoRLNaBz1cNfmoaQi99u75qyBc6Kqhbi9rd0v25QDdleYrLeEyuQPA2QvoVX6npR7fhrO+8AYN1ZGc8UebloKs=,iv:sDBhrRsqGvLBDVl+e/2xhk+f4TMheXgCtshfw7AgF7g=,tag:UP/nUrc+/qGZtWMwjV8aYQ==,type:str]
+    encrypted_regex: ^(data|stringData|ca|crt|key|id|secret|token|aggregatorCA|serviceAccount|bootstraptoken|secretboxencryptionsecret|secretboxEncryptionSecret|clientSecret|clientId)$
+    version: 3.10.2


### PR DESCRIPTION
This is used as a working example.
Add the game server for Necesse, using Linux Game Server Manager official Docker image:

- use of Docker image from LGSM for simple integration, use and maintenance
- add to let it go privileged, but LGSM image use gosu to switch to unprivileged
- snapshot often but backup less
- use of [play-it.gg tunnel](https://playit.gg/) (works even with their free tiers!)