### PR TITLE
chore(operators): upgrade CNPG fron 1.25.1 to 1.28.0

### DIFF
--- a/operators/serverside/cnpg-system/kustomization.yaml
+++ b/operators/serverside/cnpg-system/kustomization.yaml
@@ -6,4 +6,4 @@ metadata:
     argocd.argoproj.io/sync-options: ServerSideApply=true
 
 resources:
-  - https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.25/releases/cnpg-1.25.1.yaml
+  - https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.28/releases/cnpg-1.28.0.yaml


### PR DESCRIPTION
Beside several changes, one notable is related to BarmanArchive: it's not a plugin. Fortunately old way is still supported even if deprecated. Take time to upgrade your manifests :)!