### PR TITLE
Fix support for Synology storage as StorageClass

### DIFF
--- a/core/synology-csi/kustomization.yaml
+++ b/core/synology-csi/kustomization.yaml
@@ -4,10 +4,24 @@ namespace: synology-csi
 
 resources:
   - namespace.yaml
-  - https://raw.githubusercontent.com/zebernst/synology-csi-talos/refs/heads/main/deploy/kubernetes/v1.20/controller.yml
-  - https://raw.githubusercontent.com/zebernst/synology-csi-talos/refs/heads/main/deploy/kubernetes/v1.20/csi-driver.yml
-  - https://raw.githubusercontent.com/zebernst/synology-csi-talos/refs/heads/main/deploy/kubernetes/v1.20/node.yml
+  - https://raw.githubusercontent.com/SynologyOpenSource/synology-csi/refs/heads/main/deploy/kubernetes/v1.20/controller.yml
+  - https://raw.githubusercontent.com/SynologyOpenSource/synology-csi/refs/heads/main/deploy/kubernetes/v1.20/csi-driver.yml
+  - https://raw.githubusercontent.com/SynologyOpenSource/synology-csi/refs/heads/main/deploy/kubernetes/v1.20/node.yml
   - storageclass.yaml
+
+# For Talos we need to patch the deployment.
+# Ref: https://github.com/SynologyOpenSource/synology-csi/issues/89
+patches:
+  - target:
+      kind: DaemonSet
+      name: synology-csi-node
+    patch: |
+      # - op: add
+      #   path: /spec/template/spec/containers/1/args/-
+      #   value: --chroot-dir=/host
+      - op: add
+        path: /spec/template/spec/containers/1/args/-
+        value: --iscsiadm-path=/usr/local/sbin/iscsiadm
 
 generators:
   - secret-generator.yaml

--- a/core/synology-csi/kustomization.yaml
+++ b/core/synology-csi/kustomization.yaml
@@ -16,9 +16,6 @@ patches:
       kind: DaemonSet
       name: synology-csi-node
     patch: |
-      # - op: add
-      #   path: /spec/template/spec/containers/1/args/-
-      #   value: --chroot-dir=/host
       - op: add
         path: /spec/template/spec/containers/1/args/-
         value: --iscsiadm-path=/usr/local/sbin/iscsiadm


### PR DESCRIPTION
Looks like the repo from zebernst lost a container image which blocked the deployment of the StorageClass for Synology. So after checking few issues and PR I was able to deploy the official Synology support for Kubernetes, and patched it to work with Talos. They did all the job required to support Talos, just an arg is required to finalize it.