### PR TITLE
Add metube app with synology NFS support

### DIFF
--- a/apps/metube/httproute.yaml
+++ b/apps/metube/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: metube-https
+spec:
+  hostnames:
+    - metube.menia.cc
+  parentRefs:
+    - name: shared-gateway
+      namespace: default
+      sectionName: shared-https
+  rules:
+    - backendRefs:
+        - name: metube
+          port: 8081

--- a/apps/metube/kustomization.yaml
+++ b/apps/metube/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metube
+
+resources:
+  - metube.yaml
+  - httproute.yaml

--- a/apps/metube/metube.yaml
+++ b/apps/metube/metube.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metube
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: metube-pv
+spec:
+  storageClassName: synostorage-nfs
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    server: 192.168.200.222
+    path: /volume2/YouTube
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: metube-pvc
+spec:
+  storageClassName: synostorage-nfs
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: metube-pv
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metube
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: metube
+  template:
+    metadata:
+      labels:
+        app: metube
+    spec:
+      securityContext:
+        runAsUser: 1026
+        runAsGroup: 1026
+        fsGroup: 1026
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: metube
+          image: ghcr.io/alexta69/metube:2026.05.30
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: web
+              containerPort: 8081
+          env:
+            - name: PUID
+              value: "1026"
+            - name: DOWNLOAD_DIR
+              value: "/downloads"
+          volumeMounts:
+            - name: downloads
+              mountPath: /downloads
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: downloads
+          persistentVolumeClaim:
+            claimName: metube-pvc
+        - name: tmp
+          emptyDir:
+            medium: ""
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metube
+spec:
+  selector:
+    app: metube
+  ports:
+    - protocol: TCP
+      port: 8081
+      targetPort: web

--- a/core/synology-csi/storageclass.yaml
+++ b/core/synology-csi/storageclass.yaml
@@ -8,9 +8,25 @@ metadata:
 provisioner: csi.san.synology.com
 parameters:
   # fsType: 'btrfs'
-  fsType: 'ext4'
-  dsm: '192.168.200.222'
-  location: '/volume2'
+  fsType: "ext4"
+  dsm: "192.168.200.222"
+  location: "/volume2"
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+  name: synostorage-nfs
+provisioner: csi.san.synology.com
+parameters:
+  protocol: "nfs"
+  dsm: "192.168.200.222"
+  location: "/volume2"
+mountOptions:
+  - nfsvers=4.1
 reclaimPolicy: Retain
 allowVolumeExpansion: true
 ---


### PR DESCRIPTION
Bring a new app to download YouTube videos straight to a NAS shared folder.
Required a NFS connection, I used synology-csi as I already use it and NFS support is part of it. Metube downloads directly in the NAS :).