### PR TITLE
feat(apps): add open-design.ai container

### DIFF
--- a/apps/opendesign/httproute.yaml
+++ b/apps/opendesign/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: opendesign-https
+spec:
+  hostnames:
+    - opendesign.menia.cc
+  parentRefs:
+    - name: shared-gateway
+      namespace: default
+      sectionName: shared-https
+  rules:
+    - backendRefs:
+        - name: opendesign
+          port: 7456

--- a/apps/opendesign/kustomization.yaml
+++ b/apps/opendesign/kustomization.yaml
@@ -7,5 +7,5 @@ resources:
   - httproute.yaml
   - secret.yaml
 
-# generators:
-#   - secret-generator.yaml
+generators:
+  - secret-generator.yaml

--- a/apps/opendesign/kustomization.yaml
+++ b/apps/opendesign/kustomization.yaml
@@ -5,7 +5,6 @@ namespace: opendesign
 resources:
   - opendesign.yaml
   - httproute.yaml
-  - secret.yaml
 
 generators:
   - secret-generator.yaml

--- a/apps/opendesign/kustomization.yaml
+++ b/apps/opendesign/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opendesign
+
+resources:
+  - opendesign.yaml
+  - httproute.yaml
+  - secret.yaml
+
+# generators:
+#   - secret-generator.yaml

--- a/apps/opendesign/opendesign.yaml
+++ b/apps/opendesign/opendesign.yaml
@@ -1,0 +1,126 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opendesign
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: opendesign-pvc
+  labels:
+    recurring-job-group.longhorn.io/auto-backup: enabled
+    recurring-job-group.longhorn.io/auto-snapshot: enabled
+    backup-frequency: high
+    snapshot-frequency: high
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 50Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: opendesign
+spec:
+  serviceName: opendesign
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opendesign
+  template:
+    metadata:
+      labels:
+        app: opendesign
+    spec:
+      securityContext:
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: volume-permissions
+          image: busybox:1.38
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /data/.od /data/projects /data/media || true
+              chown -R 1000:1000 /data
+              chmod 700 /data || true
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      containers:
+        - name: opendesign
+          image: vanjayak/open-design:latest
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: web
+              containerPort: 7456
+          env:
+            - name: OD_DATA_DIR
+              value: "/data"
+            - name: TZ
+              value: "America/Montreal"
+            - name: OD_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: opendesign-secret
+                  key: OD_API_TOKEN
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1Gi
+            requests:
+              cpu: 200m
+              memory: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: web
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: web
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: opendesign-pvc
+        - name: tmp
+          emptyDir:
+            medium: ""
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opendesign
+spec:
+  selector:
+    app: opendesign
+  ports:
+    - protocol: TCP
+      port: 7456
+      targetPort: web

--- a/apps/opendesign/opendesign.yaml
+++ b/apps/opendesign/opendesign.yaml
@@ -36,7 +36,7 @@ spec:
         app: opendesign
     spec:
       securityContext:
-        fsGroup: 1000
+        fsGroup: 1001
         seccompProfile:
           type: RuntimeDefault
       initContainers:
@@ -47,7 +47,7 @@ spec:
             - -c
             - |
               mkdir -p /data/.od /data/projects /data/media || true
-              chown -R 1000:1000 /data
+              chown -R 1001:1001 /data
               chmod 700 /data || true
           volumeMounts:
             - name: data
@@ -56,8 +56,8 @@ spec:
         - name: opendesign
           image: vanjayak/open-design:latest
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
+            runAsUser: 1001
+            runAsGroup: 1001
             runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -70,6 +70,14 @@ spec:
             - name: web
               containerPort: 7456
           env:
+            - name: OD_BIND_HOST
+              value: "0.0.0.0"
+            - name: OD_PORT
+              value: "7456"
+            - name: OD_WEB_PORT
+              value: "7456"
+            - name: OD_ALLOWED_ORIGINS
+              value: "http://localhost,http://127.0.0.1,https://opendesign.menia.cc"
             - name: OD_DATA_DIR
               value: "/data"
             - name: TZ

--- a/apps/opendesign/secret-generator.yaml
+++ b/apps/opendesign/secret-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: opendesign-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - secret.enc.yaml

--- a/apps/opendesign/secret.enc.yaml
+++ b/apps/opendesign/secret.enc.yaml
@@ -1,0 +1,31 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: opendesign-secret
+type: Opaque
+stringData:
+    OD_API_TOKEN: ENC[AES256_GCM,data:9UVhygb68kC5Lrp4lb9okSKRgbeh2gt7dthxpU0inYvI0IAw29MLVeYhVnHCUxnkjq8=,iv:S9KGUkEA53x1xCujDpRVO5psNoWAtjTtA+Hcau9RUZc=,tag:ZwPwnsGFvhLw16rBlcn9xQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLcDM3L1NIb2swRDRnQlJ2
+            YkVQTEdDSWMxUklxYUdQUXQ4NjVCLzZjUFdnCnFiL040M25peHErN1pFMFl1Zkdp
+            U1JDekpIdzNRYm43d3pkOHcyUDduelEKLS0tIEpQcHpESVZZcHJkVmJ6NUxMUjdh
+            SFlNK1NEUDdFSVJWZk4wSWRVSWtSOU0KhyUSl6wEgPwy/LnYZ1Y1DwN42nqWqs1a
+            Px8fcXEQDao2k+dD7MfJBYc14d0VfNnyZEADai9VemLjhcfV8wM74g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ngkdczpldhxhx8qchl0v7c9eq06vnc5yea3mhsuy0n20hvyescpqv3w2xy
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRYmwwVHh2Uk1QM1M1bzhx
+            b3M2Qlk5ekZYUEdEeWF3aE93UFRVS2hsUkFZCnlpNHZqRzNBOXJXakMwMDkwZ2JR
+            L0R2M0F5Rlh2bTIrSTVuOGcxd1JiMHcKLS0tIFUvUXR1ajdpU2RFTi9pL0ZjS2s3
+            RVFHc3NIUFlDdEY2Tm5jMzNLczBtZlUK079kixJ4ebOLli2IFLcNbP0KutKTK4IA
+            370iO1qoyfKyzilnQ6BglGlAy7xT9I7KVoNXD8XYZvpeB0B1LciV1w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1xzxw8fsvdz53aa3r8z6t4zns2cqadjm4ep88w5jf4zw3yhcflvesxgkxlc
+    encrypted_regex: ^(data|stringData|ca|crt|key|id|secret|token|aggregatorCA|serviceAccount|bootstraptoken|secretboxencryptionsecret|secretboxEncryptionSecret|clientSecret|clientId)$
+    lastmodified: "2026-06-14T18:44:04Z"
+    mac: ENC[AES256_GCM,data:dPwiHsokW/On7Kr63kp9vA06mbhmYo5gVxrvxTKz1k7ZoNFDIXd1EkyS8qK3pvl4NJrIRUOgmnoP2IQk6wvFON+cXwGN0CsVB8zslj9bey1Gpabw8co4w/PQP1fi1QGtvI0s0zhL/R2EHRwSTJKvQiL/mSTqzAPsV0hiKFfaog8=,iv:/J9HpTzyLecBm5Fvzki9dhhi9w/+lVAaLkFJmq0fwwE=,tag:inzJcTX8dgjJ8twMBlg3sw==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
Open Design is an open source alternative to Claude Design that supports "Bring Your Own Key". Hopefully they will support OpenRouter and Mistral as providers in the future :).