### PR TITLE
build(deps): bump n8nio/n8n from 2.27.4 to 2.28.4 in /apps/n8n

### DIFF
--- a/apps/n8n/n8n.yaml
+++ b/apps/n8n/n8n.yaml
@@ -21,10 +21,13 @@ spec:
       storage: 2Gi
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: n8n
 spec:
+  replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: n8n
@@ -51,7 +54,7 @@ spec:
               mountPath: /data
       containers:
         - name: n8n
-          image: docker.n8n.io/n8nio/n8n:2.27.4
+          image: docker.n8n.io/n8nio/n8n:2.28.4
           envFrom:
             - secretRef:
                 name: n8n-secret
@@ -76,11 +79,11 @@ spec:
               mountPath: /home/node
           resources:
             requests:
-              memory: "250Mi"
-              cpu: "100m"
+              memory: "300Mi"
+              cpu: "400m"
             limits:
-              memory: "500Mi"
-              cpu: "300m"
+              memory: "600Mi"
+              cpu: "800m"
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Updated deployment configuration to use a Deployment kind instead of StatefulSet, adjusted resource requests and limits, and set the deployment strategy to Recreate.

---
updated-dependencies:
- dependency-name: n8nio/n8n dependency-version: 2.28.4 dependency-type: direct:production update-type: version-update:semver-minor ...