### PR TITLE
feat(n8n): add N8N_PROXY_HOPS environment variable to configuration

### DIFF
--- a/apps/n8n/n8n.yaml
+++ b/apps/n8n/n8n.yaml
@@ -71,6 +71,8 @@ spec:
               value: "production"
             - name: WEBHOOK_URL
               value: "https://n8n.btrcloud.com/"
+            - name: N8N_PROXY_HOPS
+              value: "1"
           ports:
             - name: http
               containerPort: 5678


### PR DESCRIPTION
Fix issue: https://community.n8n.io/t/x-forwarded-for-header-is-set-but-the-express-trust-proxy-s/51208