### PR TITLE
docs(monitoring): Reflect monitoring changes and examples

### DIFF
--- a/docs/src/Architecture.md
+++ b/docs/src/Architecture.md
@@ -68,6 +68,7 @@ Here are some common paths depending on what you want to understand:
 | How storage is organized                      | [Storage](Core%20Concepts/Storage/longhorn.md) (Longhorn primary + Synology CSI) |
 | How GitOps is set up                          | [GitOps / ArgoCD](Core%20Concepts/GitOps/argocd.md) |
 | How operators are managed                     | [Operators](Operators/operators.md) |
+| How monitoring is set up                      | [Maintenance / Monitoring](Maintenance/monitoring.md) |
 | How secrets are handled                       | [Security / Encryption](Core%20Concepts/Security/encryption.md) |
 
 ## Summary

--- a/docs/src/Examples/examples.md
+++ b/docs/src/Examples/examples.md
@@ -12,7 +12,7 @@ They are **not** automatically deployed by the main ApplicationSets (`apps`, `co
 
 ## Structure
 
-- `examples/apps/` — application examples
+- `examples/apps/` — application examples (e.g. game servers, whoami, Netdata)
 - `examples/core/` — core component examples (e.g. Tailscale)
 
 Many examples include `secret-generator.yaml` + `*.enc.yaml` to demonstrate the SOPS + KSOPS pattern.

--- a/docs/src/Maintenance/monitoring.md
+++ b/docs/src/Maintenance/monitoring.md
@@ -1,16 +1,36 @@
 # Monitoring
 
-## Netdata
+The cluster uses two complementary layers:
 
-Netdata is a highly performant monitoring and troubleshooting tool for Linux. My choice is motivated by the fact that it's opensource and self-hosted, with deep integration with Kubernetes and deep observability. This one will be used only locally.
+- **Beszel** — base monitoring and alerting for the cluster nodes themselves (lightweight, day-to-day host health).
+- **VictoriaMetrics** — deeper observability (Prometheus-compatible scraping, long-term storage, Grafana, Alertmanager). It is better suited to rich metrics pipelines and is intended to monitor services beyond the cluster, not only the nodes.
 
-It is deployed under `core/netdata/`.
+## Beszel
 
-> **Note:** The free / open-source version of Netdata is limited to a maximum of 5 nodes.
+[Beszel](https://beszel.dev/) is a lightweight, self-hosted monitoring hub with per-node agents. It provides the base monitoring and alerting layer for the Talos nodes (CPU, memory, disk, network).
+
+It is deployed under `core/beszel/`:
+
+- **Hub** — Deployment + Longhorn PVC, UI at `https://mon.menia.cc` (LAN-only HTTPRoute)
+- **Agents** — DaemonSet (`hostNetwork`) on every node, including control-plane; agents connect to the hub over WebSocket
+
+Secrets (`KEY` = hub public SSH key, `TOKEN` = universal registration token) live in `core/beszel/secret.enc.yaml` (SOPS). After rotating the token in the hub UI (`/settings/tokens`), update the secret and restart the DaemonSet.
+
+Notes specific to this cluster:
+
+- Agents use WebSocket only (`DISABLE_SSH=true`); they talk to the in-cluster hub Service, not the Gateway.
+- Talos uses containerd, not Docker/Podman — container metrics from Beszel are not available (`DOCKER_HOST=""`).
+- Namespace PSA stays `privileged` because agents need `hostNetwork` (required for host NIC stats). Containers themselves are non-root / least-privilege.
+
+### Alerting
+
+Beszel can send alerts when systems go down or cross thresholds (CPU, memory, disk, etc.). Notifications are configured in the hub UI (**Settings → Notifications**) as [Shoutrrr](https://containrrr.dev/shoutrrr/) URLs — one library, many backends (Pushover, Discord, Slack, Gotify, email, …).
+
+On my cluster, alerts go through **Pushover**. Other channels are just another Shoutrrr URL away if needed. Per-system alerts are enabled from the systems table in the UI.
 
 ## VictoriaMetrics
 
-VictoriaMetrics is deployed for cluster-wide metrics collection, long-term storage, alerting and visualization.
+VictoriaMetrics is the deep observability stack: cluster-wide metrics collection, long-term storage, alerting and visualization. Beyond node health, the goal is to scrape and monitor other services (applications, operators, exporters) with a Prometheus-compatible model.
 
 It is installed using the official **VictoriaMetrics Operator** together with the `victoria-metrics-k8s-stack` Helm chart, under `operators/serverside/victoria-metrics/`.
 
@@ -25,11 +45,22 @@ All these services are exposed via HTTPRoutes on the LAN (they are not publicly 
 
 This setup was chosen as a high-performance, Prometheus-compatible replacement for the classic Prometheus + Alertmanager + Grafana stack, with much better storage efficiency.
 
+## Netdata (example only)
+
+Netdata used to live under `core/` as a local troubleshooting UI. It was dropped as an active cluster component after a license change last year that limits the free / open-source edition to a maximum of **5 nodes**.
+
+The manifests were moved to `examples/apps/netdata/` (not auto-deployed by the main ApplicationSets) and are kept only as a **reference / inspiration** if someone wants to experiment with that stack again.
+
 ## References
 
-**Netdata**
-- [Netdata Documentation](https://learn.netdata.cloud/)
-- [Netdata Kubernetes Monitoring](https://learn.netdata.cloud/docs/collecting-metrics/kubernetes-k8s)
+**Beszel**
+- [Beszel Documentation](https://beszel.dev/)
+- [Hub installation](https://beszel.dev/guide/hub-installation)
+- [Agent installation](https://beszel.dev/guide/agent-installation)
+- [Kubernetes / advanced deployment](https://beszel.dev/guide/advanced-deployment)
+- [Notifications (Shoutrrr)](https://beszel.dev/guide/notifications/)
+- [Pushover](https://beszel.dev/guide/notifications/pushover)
+- [Shoutrrr services overview](https://containrrr.dev/shoutrrr/v0.8/services/overview/)
 
 **VictoriaMetrics**
 - [VictoriaMetrics Official Documentation](https://docs.victoriametrics.com/)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -80,7 +80,7 @@ The project is a pure declarative GitOps repository. Source of truth = the YAML 
 | Folder          | Description |
 | ---             | --- |
 | `apps/`         | User workloads. Each subdirectory = one ArgoCD Application (namespace = dir basename). Includes `apps/serverside/*` for ServerSideApply workloads. |
-| `core/`         | Essential cluster components (ArgoCD, Cilium is under infra, Longhorn, cert-manager, external-dns, cloudflared, netdata, etc.). |
+| `core/`         | Essential cluster components (ArgoCD, Cilium is under infra, Longhorn, cert-manager, external-dns, cloudflared, beszel, etc.). |
 | `operators/`    | Kubernetes operators (CNPG, MariaDB, VictoriaMetrics, ...). Includes `operators/serverside/*`. |
 | `infra/`        | Infrastructure configs. Contains the encrypted Talos controlplane and worker machine configs (`controlplane.enc.yaml`, `worker.enc.yaml`, `secrets.enc.yaml`) plus the `infra/cilium/` subdirectory (CNI + Gateway + L2 announcements). |
 | `examples/`     | Preview / non-production examples (not auto-deployed by the main ApplicationSets). |


### PR DESCRIPTION
- Added a section on monitoring setup, detailing the use of Beszel and VictoriaMetrics.
- Updated the Architecture.md to include monitoring information.
- Revised examples.md to clarify the purpose of application examples.
- Moved Netdata documentation to examples as it is no longer an active cluster component.

Address #53  